### PR TITLE
First pass at an HTML season points report

### DIFF
--- a/modules/core-test/pom.xml
+++ b/modules/core-test/pom.xml
@@ -34,6 +34,11 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/modules/core-test/src/main/kotlin/org/coner/trailer/TestEvents.kt
+++ b/modules/core-test/src/main/kotlin/org/coner/trailer/TestEvents.kt
@@ -53,6 +53,21 @@ object TestEvents {
             )
     }
 
+    object Lscc2019Simplified {
+        val points1 by lazy { Event(
+                date = LocalDate.parse("2019-01-01"),
+                name = "2019 LSCC Simplified Points Event #1"
+        ) }
+        val points2 by lazy { Event(
+                date = LocalDate.parse("2019-02-02"),
+                name = "2019 LSCC Simplified Points Event #2"
+        ) }
+        val points3 by lazy { Event(
+                date = LocalDate.parse("2019-03-03"),
+                name = "2019 LSCC Simplified Points Event #3"
+        ) }
+    }
+
     object Olscc2019 {
         val points1: Event
             get() = Event(

--- a/modules/core-test/src/main/kotlin/org/coner/trailer/TestPeople.kt
+++ b/modules/core-test/src/main/kotlin/org/coner/trailer/TestPeople.kt
@@ -4,22 +4,22 @@ object TestPeople {
 
     // Fictional names only
 
-    val DOMINIC_ROGERS by lazy { factory("Dominic Rogers") }
-    val BRANDY_HUFF by lazy { factory("Brandy Huff") }
-    val BRYANT_MORAN by lazy { factory("Bryant Moran") }
-    val REBECCA_JACKSON by lazy { factory("Rebecca Jackson") }
-    val ANASTASIA_RIGLER by lazy { factory("Anastasia Rigler") }
-    val JIMMY_MCKENZIE by lazy { factory("Jimmy Mckenzie") }
-    val EUGENE_DRAKE by lazy { factory("Eugene Drake") }
-    val BENNETT_PANTONE by lazy { factory("Bennett Pantone") }
+    val DOMINIC_ROGERS by lazy { factory("Dominic Rogers", "2019-00061") }
+    val BRANDY_HUFF by lazy { factory("Brandy Huff", "2019-00080") }
+    val BRYANT_MORAN by lazy { factory("Bryant Moran", "2019-00125") }
+    val REBECCA_JACKSON by lazy { factory("Rebecca Jackson", "1807") }
+    val ANASTASIA_RIGLER by lazy { factory("Anastasia Rigler", "2019-00094") }
+    val JIMMY_MCKENZIE by lazy { factory("Jimmy Mckenzie", "2476") }
+    val EUGENE_DRAKE by lazy { factory("Eugene Drake", "2019-00057") }
+    val BENNETT_PANTONE by lazy { factory("Bennett Pantone", "2019-00295") }
     val TERI_POTTER by lazy { factory("Teri Potter") }
     val HARRY_WEBSTER by lazy { factory("Harry Webster") }
     val NORMAN_ROBINSON by lazy { factory("Norman Robinson") }
     val JOHNNIE_ROWE by lazy { factory("Johnnie Rowe") }
 
-    private fun factory(name: String): Person {
+    private fun factory(name: String, memberId: String? = null): Person {
         return Person(
-                memberId = name.toLowerCase().replace(oldChar = ' ', newChar = '-'),
+                memberId = memberId ?: name.toLowerCase().replace(oldChar = ' ', newChar = '-'),
                 name = name
         )
     }

--- a/modules/core-test/src/main/kotlin/org/coner/trailer/TestPeople.kt
+++ b/modules/core-test/src/main/kotlin/org/coner/trailer/TestPeople.kt
@@ -12,8 +12,8 @@ object TestPeople {
     val JIMMY_MCKENZIE by lazy { factory("Jimmy Mckenzie", "2476") }
     val EUGENE_DRAKE by lazy { factory("Eugene Drake", "2019-00057") }
     val BENNETT_PANTONE by lazy { factory("Bennett Pantone", "2019-00295") }
-    val TERI_POTTER by lazy { factory("Teri Potter") }
-    val HARRY_WEBSTER by lazy { factory("Harry Webster") }
+    val TERI_POTTER by lazy { factory("Teri Potter", "2019-00051") }
+    val HARRY_WEBSTER by lazy { factory("Harry Webster", "2276") }
     val NORMAN_ROBINSON by lazy { factory("Norman Robinson") }
     val JOHNNIE_ROWE by lazy { factory("Johnnie Rowe") }
 

--- a/modules/core-test/src/main/kotlin/org/coner/trailer/TestSeasonEvents.kt
+++ b/modules/core-test/src/main/kotlin/org/coner/trailer/TestSeasonEvents.kt
@@ -23,6 +23,21 @@ object TestSeasonEvents {
             get() = points(event = TestEvents.Lscc2019.points9, eventNumber = 9)
     }
 
+    object Lscc2019Simplified {
+        val points1 by lazy { points(
+                event = TestEvents.Lscc2019Simplified.points1,
+                eventNumber = 1
+        ) }
+        val points2 by lazy { points(
+                event = TestEvents.Lscc2019Simplified.points2,
+                eventNumber = 2
+        ) }
+        val points3 by lazy { points(
+                event = TestEvents.Lscc2019Simplified.points3,
+                eventNumber = 3
+        ) }
+    }
+
     object LsccTieBreaking {
         val points1: SeasonEvent get() = points(
                 event = TestEvents.Lscc2019.points1,

--- a/modules/core-test/src/main/kotlin/org/coner/trailer/TestSeasons.kt
+++ b/modules/core-test/src/main/kotlin/org/coner/trailer/TestSeasons.kt
@@ -28,6 +28,20 @@ object TestSeasons {
             )
     )
 
+    val lscc2019Simplified by lazy { Season(
+            name = "LSCC 2019 Simplified",
+            seasonPointsCalculatorConfigurationModel = CalculatorConfigurationModel(mapOf(
+                    StandardResultsTypes.competitionGrouped to lsccGroupingCalculator,
+                    StandardResultsTypes.overallRawTime to lsccOverallCalculator,
+                    StandardResultsTypes.overallHandicapTime to lsccOverallCalculator
+            )),
+            events = listOf(
+                    TestSeasonEvents.Lscc2019Simplified.points1,
+                    TestSeasonEvents.Lscc2019Simplified.points2,
+                    TestSeasonEvents.Lscc2019Simplified.points3
+            )
+    ) }
+
     val olscc2019: Season
         get() = Season(
                 name = "OLSCC 2019",

--- a/modules/core-test/src/main/kotlin/org/coner/trailer/TestSeasons.kt
+++ b/modules/core-test/src/main/kotlin/org/coner/trailer/TestSeasons.kt
@@ -28,6 +28,19 @@ object TestSeasons {
             )
     )
 
+    val lscc2019TieBreaking by lazy { Season(
+            name = "LSCC 2019 Tie-Breaking",
+            seasonPointsCalculatorConfigurationModel = CalculatorConfigurationModel(mapOf(
+                    StandardResultsTypes.competitionGrouped to lsccGroupingCalculator,
+                    StandardResultsTypes.overallRawTime to lsccOverallCalculator,
+                    StandardResultsTypes.overallHandicapTime to lsccOverallCalculator
+            )),
+            events = listOf(
+                    TestSeasonEvents.LsccTieBreaking.points1,
+                    TestSeasonEvents.LsccTieBreaking.points2
+            )
+    ) }
+
     val lscc2019Simplified by lazy { Season(
             name = "LSCC 2019 Simplified",
             seasonPointsCalculatorConfigurationModel = CalculatorConfigurationModel(mapOf(

--- a/modules/core-test/src/main/kotlin/org/coner/trailer/seasonpoints/TestStandingsReports.kt
+++ b/modules/core-test/src/main/kotlin/org/coner/trailer/seasonpoints/TestStandingsReports.kt
@@ -161,7 +161,7 @@ object TestStandingsReports {
                                     )
                             )
                     ),
-                    seasonEvents = TestSeasons.lscc2019.events
+                    pointsEvents = TestSeasons.lscc2019.events
             )
         }
 
@@ -278,7 +278,7 @@ object TestStandingsReports {
                                 )
                         )
                 ),
-                seasonEvents = TestSeasons.lscc2019Simplified.events
+                pointsEvents = TestSeasons.lscc2019Simplified.events
         )
     }
 }

--- a/modules/core-test/src/main/kotlin/org/coner/trailer/seasonpoints/TestStandingsReports.kt
+++ b/modules/core-test/src/main/kotlin/org/coner/trailer/seasonpoints/TestStandingsReports.kt
@@ -3,6 +3,7 @@ package org.coner.trailer.seasonpoints
 import org.coner.trailer.TestGroupings
 import org.coner.trailer.TestPeople
 import org.coner.trailer.TestSeasonEvents
+import org.coner.trailer.TestSeasons
 
 object TestStandingsReports {
 
@@ -16,7 +17,7 @@ object TestStandingsReports {
                                             StandingsReport.Standing(
                                                     position = 1,
                                                     person = TestPeople.DOMINIC_ROGERS,
-                                                    eventToPoints = mapOf(
+                                                    eventToPoints = sortedMapOf(
                                                             TestSeasonEvents.Lscc2019.points1 to 1,
                                                             TestSeasonEvents.Lscc2019.points2 to 6,
                                                             TestSeasonEvents.Lscc2019.points3 to 1,
@@ -31,7 +32,7 @@ object TestStandingsReports {
                                             StandingsReport.Standing(
                                                     position = 2,
                                                     person = TestPeople.BRANDY_HUFF,
-                                                    eventToPoints = mapOf(
+                                                    eventToPoints = sortedMapOf(
                                                             TestSeasonEvents.Lscc2019.points1 to 3,
                                                             TestSeasonEvents.Lscc2019.points2 to 9,
                                                             TestSeasonEvents.Lscc2019.points3 to 9,
@@ -43,7 +44,7 @@ object TestStandingsReports {
                                             StandingsReport.Standing(
                                                     position = 3,
                                                     person = TestPeople.BRYANT_MORAN,
-                                                    eventToPoints = mapOf(
+                                                    eventToPoints = sortedMapOf(
                                                             TestSeasonEvents.Lscc2019.points1 to 1,
                                                             TestSeasonEvents.Lscc2019.points3 to 1,
                                                             TestSeasonEvents.Lscc2019.points4 to 3,
@@ -63,7 +64,7 @@ object TestStandingsReports {
                                             StandingsReport.Standing(
                                                     position = 1,
                                                     person = TestPeople.REBECCA_JACKSON,
-                                                    eventToPoints = mapOf(
+                                                    eventToPoints = sortedMapOf(
                                                             TestSeasonEvents.Lscc2019.points2 to 9,
                                                             TestSeasonEvents.Lscc2019.points3 to 9,
                                                             TestSeasonEvents.Lscc2019.points4 to 9,
@@ -78,7 +79,7 @@ object TestStandingsReports {
                                             StandingsReport.Standing(
                                                     position = 2,
                                                     person = TestPeople.JIMMY_MCKENZIE,
-                                                    eventToPoints = mapOf(
+                                                    eventToPoints = sortedMapOf(
                                                             TestSeasonEvents.Lscc2019.points1 to 3,
                                                             TestSeasonEvents.Lscc2019.points2 to 4,
                                                             TestSeasonEvents.Lscc2019.points3 to 4,
@@ -94,7 +95,7 @@ object TestStandingsReports {
                                             StandingsReport.Standing(
                                                     position = 3,
                                                     person = TestPeople.EUGENE_DRAKE,
-                                                    eventToPoints =  mapOf(
+                                                    eventToPoints =  sortedMapOf(
                                                             TestSeasonEvents.Lscc2019.points1 to 6,
                                                             TestSeasonEvents.Lscc2019.points3 to 3,
                                                             TestSeasonEvents.Lscc2019.points4 to 4,
@@ -113,7 +114,7 @@ object TestStandingsReports {
                                             StandingsReport.Standing(
                                                     position = 1,
                                                     person = TestPeople.TERI_POTTER,
-                                                    eventToPoints = mapOf(
+                                                    eventToPoints = sortedMapOf(
                                                             TestSeasonEvents.Lscc2019.points1 to 6,
                                                             TestSeasonEvents.Lscc2019.points2 to 9,
                                                             TestSeasonEvents.Lscc2019.points3 to 3,
@@ -129,7 +130,7 @@ object TestStandingsReports {
                                             StandingsReport.Standing(
                                                     position = 2,
                                                     person = TestPeople.HARRY_WEBSTER,
-                                                    eventToPoints = mapOf(
+                                                    eventToPoints = sortedMapOf(
                                                             TestSeasonEvents.Lscc2019.points3 to 6,
                                                             TestSeasonEvents.Lscc2019.points4 to 6,
                                                             TestSeasonEvents.Lscc2019.points5 to 6,
@@ -143,7 +144,7 @@ object TestStandingsReports {
                                             StandingsReport.Standing(
                                                     position = 3,
                                                     person = TestPeople.NORMAN_ROBINSON,
-                                                    eventToPoints = mapOf(
+                                                    eventToPoints = sortedMapOf(
                                                             TestSeasonEvents.Lscc2019.points1 to 4,
                                                             TestSeasonEvents.Lscc2019.points1 to 2,
                                                             TestSeasonEvents.Lscc2019.points3 to 2,
@@ -159,7 +160,125 @@ object TestStandingsReports {
                                             )
                                     )
                             )
-                    )
+                    ),
+                    seasonEvents = TestSeasons.lscc2019.events
             )
         }
+
+    val lscc2019Simplified by lazy {
+        val seasonEvents = TestSeasonEvents.Lscc2019Simplified
+        StandingsReport(
+                sections = listOf(
+                        StandingsReport.Section(
+                                title = TestGroupings.Lscc2019.HS.name,
+                                standings = listOf(
+                                        StandingsReport.Standing(
+                                                position = 1,
+                                                person = TestPeople.ANASTASIA_RIGLER,
+                                                eventToPoints = sortedMapOf(
+                                                        seasonEvents.points1 to 9,
+                                                        seasonEvents.points2 to 9,
+                                                        seasonEvents.points3 to 9
+                                                ),
+                                                score = 18,
+                                                tie = false
+                                        ),
+                                        StandingsReport.Standing(
+                                                position = 2,
+                                                person = TestPeople.REBECCA_JACKSON,
+                                                eventToPoints = sortedMapOf(
+                                                        seasonEvents.points1 to 6
+                                                ),
+                                                score = 6,
+                                                tie = false
+                                        )
+                                )
+                        ),
+                        StandingsReport.Section(
+                                title = TestGroupings.Lscc2019.STR.name,
+                                standings = listOf(
+                                        StandingsReport.Standing(
+                                                position = 1,
+                                                person = TestPeople.REBECCA_JACKSON,
+                                                eventToPoints = sortedMapOf(
+                                                        seasonEvents.points2 to 9,
+                                                        seasonEvents.points3 to 9
+                                                ),
+                                                score = 18,
+                                                tie = false
+                                        ),
+                                        StandingsReport.Standing(
+                                                position = 2,
+                                                person = TestPeople.EUGENE_DRAKE,
+                                                eventToPoints = sortedMapOf(
+                                                        seasonEvents.points1 to 9,
+                                                        seasonEvents.points3 to 4
+                                                ),
+                                                score = 13,
+                                                tie = false
+                                        ),
+                                        StandingsReport.Standing(
+                                                position = 3,
+                                                person = TestPeople.JIMMY_MCKENZIE,
+                                                eventToPoints = sortedMapOf(
+                                                        seasonEvents.points1 to 6,
+                                                        seasonEvents.points2 to 6,
+                                                        seasonEvents.points3 to 6
+                                                ),
+                                                score = 12,
+                                                tie = false
+                                        )
+                                )
+                        ),
+                        StandingsReport.Section(
+                                title = TestGroupings.Lscc2019.NOV.name,
+                                standings = listOf(
+                                        StandingsReport.Standing(
+                                                position = 1,
+                                                person = TestPeople.BRANDY_HUFF,
+                                                eventToPoints = sortedMapOf(
+                                                        seasonEvents.points1 to 9,
+                                                        seasonEvents.points2 to 9,
+                                                        seasonEvents.points3 to 9
+                                                ),
+                                                score = 18,
+                                                tie = false
+                                        ),
+                                        StandingsReport.Standing(
+                                                position = 2,
+                                                person = TestPeople.BRYANT_MORAN,
+                                                eventToPoints = sortedMapOf(
+                                                        seasonEvents.points1 to 6,
+                                                        seasonEvents.points3 to 6
+                                                ),
+                                                score = 12,
+                                                tie = false
+                                        ),
+                                        StandingsReport.Standing(
+                                                position = 3,
+                                                person = TestPeople.DOMINIC_ROGERS,
+                                                eventToPoints = sortedMapOf(
+                                                        seasonEvents.points1 to 4,
+                                                        seasonEvents.points2 to 6,
+                                                        seasonEvents.points3 to 4
+                                                ),
+                                                score = 10,
+                                                tie = false
+                                        ),
+                                        StandingsReport.Standing(
+                                                position = 4,
+                                                person = TestPeople.BENNETT_PANTONE,
+                                                eventToPoints = sortedMapOf(
+                                                        seasonEvents.points2 to 4,
+                                                        seasonEvents.points3 to 3
+                                                ),
+                                                score = 7,
+                                                tie = false
+                                        )
+                                )
+                        )
+                ),
+                seasonEvents = TestSeasons.lscc2019Simplified.events
+        )
+    }
 }

--- a/modules/core-test/src/main/kotlin/org/coner/trailer/seasonpoints/TestStandingsReports.kt
+++ b/modules/core-test/src/main/kotlin/org/coner/trailer/seasonpoints/TestStandingsReports.kt
@@ -166,7 +166,67 @@ object TestStandingsReports {
         }
 
     val lscc2019TieBreaking by lazy {
-        TODO()
+        val seasonEvents = TestSeasonEvents.LsccTieBreaking
+        StandingsReport(
+                sections = listOf(
+                        StandingsReport.Section(
+                                title = TestGroupings.Lscc2019.HS.name,
+                                standings = listOf(
+                                        StandingsReport.Standing(
+                                                position = 1,
+                                                person = TestPeople.REBECCA_JACKSON,
+                                                eventToPoints = sortedMapOf(
+                                                        seasonEvents.points1 to 9,
+                                                        seasonEvents.points2 to 6
+                                                ),
+                                                score = 15,
+                                                tie = true
+                                        ),
+                                        StandingsReport.Standing(
+                                                position = 1,
+                                                person = TestPeople.JIMMY_MCKENZIE,
+                                                eventToPoints = sortedMapOf(
+                                                        seasonEvents.points1 to 6,
+                                                        seasonEvents.points2 to 9
+                                                ),
+                                                score = 15,
+                                                tie = true
+                                        ),
+                                        StandingsReport.Standing(
+                                                position = 2,
+                                                person = TestPeople.EUGENE_DRAKE,
+                                                eventToPoints = sortedMapOf(
+                                                        seasonEvents.points1 to 4,
+                                                        seasonEvents.points2 to 4
+                                                ),
+                                                score = 8,
+                                                tie = false
+                                        ),
+                                        StandingsReport.Standing(
+                                                position = 3,
+                                                person = TestPeople.TERI_POTTER,
+                                                eventToPoints = sortedMapOf(
+                                                        seasonEvents.points1 to 3,
+                                                        seasonEvents.points2 to 2
+                                                ),
+                                                score = 5,
+                                                tie = true
+                                        ),
+                                        StandingsReport.Standing(
+                                                position = 3,
+                                                person = TestPeople.HARRY_WEBSTER,
+                                                eventToPoints = sortedMapOf(
+                                                        seasonEvents.points1 to 2,
+                                                        seasonEvents.points2 to 3
+                                                ),
+                                                score = 5,
+                                                tie = true
+                                        )
+                                )
+                        )
+                ),
+                pointsEvents = TestSeasons.lscc2019TieBreaking.events
+        )
     }
 
     val lscc2019Simplified by lazy {

--- a/modules/core-test/src/main/kotlin/org/coner/trailer/seasonpoints/TestStandingsReports.kt
+++ b/modules/core-test/src/main/kotlin/org/coner/trailer/seasonpoints/TestStandingsReports.kt
@@ -165,6 +165,10 @@ object TestStandingsReports {
             )
         }
 
+    val lscc2019TieBreaking by lazy {
+        TODO()
+    }
+
     val lscc2019Simplified by lazy {
         val seasonEvents = TestSeasonEvents.Lscc2019Simplified
         StandingsReport(

--- a/modules/core-test/src/test/kotlin/org/coner/trailer/SeasonEventTest.kt
+++ b/modules/core-test/src/test/kotlin/org/coner/trailer/SeasonEventTest.kt
@@ -65,7 +65,7 @@ class SeasonEventTest {
         val one = TestSeasonEvents.Lscc2019Simplified.points1
         val testAndTune = SeasonEvent(
                 event = Event(
-                        date = LocalDate.parse("2019-02-01"), // important
+                        date = LocalDate.parse("2019-02-01"), // important: after "one", before "two"
                         name = "Test and Tune"
                 ),
                 points = false,

--- a/modules/core-test/src/test/kotlin/org/coner/trailer/SeasonEventTest.kt
+++ b/modules/core-test/src/test/kotlin/org/coner/trailer/SeasonEventTest.kt
@@ -1,0 +1,41 @@
+package org.coner.trailer
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+
+class SeasonEventTest {
+
+    @Test
+    fun `Its constructor should not throw when event number is null and points is false`() {
+        val event = TestEvents.Lscc2019.points1
+
+        assertDoesNotThrow {
+            SeasonEvent(
+                    event = event,
+                    eventNumber = null, // important
+                    points = false, // important
+                    seasonPointsCalculatorConfigurationModel = null
+            )
+        }
+    }
+
+    @Test
+    fun `Its constructor should throw when event number is null and points is true`() {
+        val event = TestEvents.Lscc2019.points1
+
+        assertThrows<IllegalArgumentException> {
+            SeasonEvent(
+                    event = event,
+                    eventNumber = null, // important
+                    points = true, // important
+                    seasonPointsCalculatorConfigurationModel = null
+            )
+        }
+    }
+
+    @Test
+    fun `It should compare events correctly`() {
+        TODO()
+    }
+}

--- a/modules/core-test/src/test/kotlin/org/coner/trailer/SeasonEventTest.kt
+++ b/modules/core-test/src/test/kotlin/org/coner/trailer/SeasonEventTest.kt
@@ -1,8 +1,13 @@
 package org.coner.trailer
 
+import assertk.assertThat
+import assertk.assertions.isNegative
+import assertk.assertions.isPositive
+import assertk.assertions.isZero
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
 
 class SeasonEventTest {
 
@@ -35,7 +40,62 @@ class SeasonEventTest {
     }
 
     @Test
-    fun `It should compare events correctly`() {
-        TODO()
+    fun `It should compare SeasonEvents with eventNumbers`() {
+        val one = TestSeasonEvents.Lscc2019Simplified.points1
+        val two = TestSeasonEvents.Lscc2019Simplified.points2
+
+        // one to two
+        val actualOneToTwo = one.compareTo(two)
+
+        assertThat(actualOneToTwo, "comparing one to two").isNegative()
+
+        // two to one
+        val actualTwoToOne = two.compareTo(one)
+
+        assertThat(actualTwoToOne, "comparing two to one").isPositive()
+
+        // one to one
+        val actualOneToOne = one.compareTo(one)
+
+        assertThat(actualOneToOne, "comparing one to one").isZero()
+    }
+
+    @Test
+    fun `It should compare SeasonEvents without eventNumbers`() {
+        val one = TestSeasonEvents.Lscc2019Simplified.points1
+        val testAndTune = SeasonEvent(
+                event = Event(
+                        date = LocalDate.parse("2019-02-01"), // important
+                        name = "Test and Tune"
+                ),
+                points = false,
+                eventNumber = null
+        )
+        val two = TestSeasonEvents.Lscc2019Simplified.points2
+
+        // one to test and tune
+        val actualOneToTestAndTune = one.compareTo(testAndTune)
+
+        assertThat(actualOneToTestAndTune, "comparing one to test and tune").isNegative()
+
+        // test and tune to one
+        val actualTestAndTuneToOne = testAndTune.compareTo(one)
+
+        assertThat(actualTestAndTuneToOne, "comparing test and tune to one").isPositive()
+
+        // test and tune to self
+        val actualSelfToSelf = testAndTune.compareTo(testAndTune)
+
+        assertThat(actualSelfToSelf, "comparing test and tune to self").isZero()
+
+        // test and tune to two
+        val actualTestAndTuneToTwo = testAndTune.compareTo(two)
+
+        assertThat(actualTestAndTuneToTwo, "comparing test and tune to two").isNegative()
+
+        // two to test and tune
+        val actualTwoToTestAndTune = two.compareTo(testAndTune)
+
+        assertThat(actualTwoToTestAndTune, "comparing two to test and tune").isPositive()
     }
 }

--- a/modules/core-test/src/test/kotlin/org/coner/trailer/seasonpoints/KotlinxHtmlStandingsReportRendererTest.kt
+++ b/modules/core-test/src/test/kotlin/org/coner/trailer/seasonpoints/KotlinxHtmlStandingsReportRendererTest.kt
@@ -52,9 +52,11 @@ class KotlinxHtmlStandingsReportRendererTest {
 
         val actual = renderer.renderContentOnly(TestStandingsReports.lscc2019TieBreaking)
 
+        val actualDocument = Jsoup.parseBodyFragment(actual)
+        browseTo(actualDocument)
     }
 
-    @Deprecated
+    @Deprecated(message = "Remove prior to caeos/coner-trailer#13 completion")
     private fun browseTo(actualDocument: Document) {
         val file = createTempFile().apply { writeText(actualDocument.toString()) }
         Desktop.getDesktop().browse(file.toURI())

--- a/modules/core-test/src/test/kotlin/org/coner/trailer/seasonpoints/KotlinxHtmlStandingsReportRendererTest.kt
+++ b/modules/core-test/src/test/kotlin/org/coner/trailer/seasonpoints/KotlinxHtmlStandingsReportRendererTest.kt
@@ -1,5 +1,14 @@
 package org.coner.trailer.seasonpoints
 
+import assertk.all
+import assertk.assertAll
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.index
+import assertk.assertions.isEqualTo
+import assertk.assertions.prop
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
 import org.junit.jupiter.api.Test
 
 class KotlinxHtmlStandingsReportRendererTest {
@@ -12,6 +21,26 @@ class KotlinxHtmlStandingsReportRendererTest {
 
         val actual = renderer.renderContentOnly(TestStandingsReports.lscc2019Simplified)
 
-        TODO("parse with jsoup and assert")
+        val actualDocument = Jsoup.parseBodyFragment(actual)
+        assertAll {
+            val actualFragment = actualDocument.body().children().single()
+            assertThat(actualFragment, "rendered fragment")
+                    .transform("id") { it.attr("id") }
+                    .isEqualTo("season-points-standings")
+
+            val actualSections = actualDocument.select("section")
+            assertThat(actualSections, "rendered sections").all {
+                hasSize(3)
+                index(0).all {
+                    transform("only child") { it.children().single() }.all {
+                        prop(Element::normalName).isEqualTo("table")
+                        transform("caption") { it.select("caption").single() }.all {
+                            prop("text") { it.text() }.isEqualTo("H Street")
+                        }
+                    }
+
+                }
+            }
+        }
     }
 }

--- a/modules/core-test/src/test/kotlin/org/coner/trailer/seasonpoints/KotlinxHtmlStandingsReportRendererTest.kt
+++ b/modules/core-test/src/test/kotlin/org/coner/trailer/seasonpoints/KotlinxHtmlStandingsReportRendererTest.kt
@@ -8,8 +8,10 @@ import assertk.assertions.index
 import assertk.assertions.isEqualTo
 import assertk.assertions.prop
 import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import org.junit.jupiter.api.Test
+import java.awt.Desktop
 
 class KotlinxHtmlStandingsReportRendererTest {
 
@@ -27,7 +29,7 @@ class KotlinxHtmlStandingsReportRendererTest {
             assertThat(actualFragment, "rendered fragment")
                     .transform("id") { it.attr("id") }
                     .isEqualTo("season-points-standings")
-
+            browseTo(actualDocument)
             val actualSections = actualDocument.select("section")
             assertThat(actualSections, "rendered sections").all {
                 hasSize(3)
@@ -42,5 +44,20 @@ class KotlinxHtmlStandingsReportRendererTest {
                 }
             }
         }
+    }
+
+    @Test
+    fun `It should render content-only for Lscc2019TieBreaking report`() {
+        renderer = KotlinxHtmlStandingsReportRenderer()
+
+        val actual = renderer.renderContentOnly(TestStandingsReports.lscc2019TieBreaking)
+
+    }
+
+    @Deprecated
+    private fun browseTo(actualDocument: Document) {
+        val file = createTempFile().apply { writeText(actualDocument.toString()) }
+        Desktop.getDesktop().browse(file.toURI())
+        Thread.sleep(2000)
     }
 }

--- a/modules/core-test/src/test/kotlin/org/coner/trailer/seasonpoints/KotlinxHtmlStandingsReportRendererTest.kt
+++ b/modules/core-test/src/test/kotlin/org/coner/trailer/seasonpoints/KotlinxHtmlStandingsReportRendererTest.kt
@@ -1,0 +1,17 @@
+package org.coner.trailer.seasonpoints
+
+import org.junit.jupiter.api.Test
+
+class KotlinxHtmlStandingsReportRendererTest {
+
+    lateinit var renderer: KotlinxHtmlStandingsReportRenderer
+
+    @Test
+    fun `It should render content-only for LSCC2019Simplified report`() {
+        renderer = KotlinxHtmlStandingsReportRenderer()
+
+        val actual = renderer.renderContentOnly(TestStandingsReports.lscc2019Simplified)
+
+        TODO("parse with jsoup and assert")
+    }
+}

--- a/modules/core-test/src/test/kotlin/org/coner/trailer/seasonpoints/KotlinxHtmlStandingsReportRendererTest.kt
+++ b/modules/core-test/src/test/kotlin/org/coner/trailer/seasonpoints/KotlinxHtmlStandingsReportRendererTest.kt
@@ -29,7 +29,6 @@ class KotlinxHtmlStandingsReportRendererTest {
             assertThat(actualFragment, "rendered fragment")
                     .transform("id") { it.attr("id") }
                     .isEqualTo("season-points-standings")
-            browseTo(actualDocument)
             val actualSections = actualDocument.select("section")
             assertThat(actualSections, "rendered sections").all {
                 hasSize(3)
@@ -53,13 +52,6 @@ class KotlinxHtmlStandingsReportRendererTest {
         val actual = renderer.renderContentOnly(TestStandingsReports.lscc2019TieBreaking)
 
         val actualDocument = Jsoup.parseBodyFragment(actual)
-        browseTo(actualDocument)
     }
 
-    @Deprecated(message = "Remove prior to caeos/coner-trailer#13 completion")
-    private fun browseTo(actualDocument: Document) {
-        val file = createTempFile().apply { writeText(actualDocument.toString()) }
-        Desktop.getDesktop().browse(file.toURI())
-        Thread.sleep(2000)
-    }
 }

--- a/modules/core-test/src/test/kotlin/org/coner/trailer/seasonpoints/StandingsReportTest.kt
+++ b/modules/core-test/src/test/kotlin/org/coner/trailer/seasonpoints/StandingsReportTest.kt
@@ -1,0 +1,47 @@
+package org.coner.trailer.seasonpoints
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.messageContains
+import io.mockk.every
+import io.mockk.mockk
+import org.coner.trailer.SeasonEvent
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+
+class StandingsReportTest {
+
+    @Test
+    fun `Its constructor should throw if any pointsEvents are non-points`() {
+        val nonPointsSeasonEvent = mockk<SeasonEvent> {
+            every { points }.returns(false)
+        }
+
+        val actual = assertThrows<IllegalArgumentException> {
+            StandingsReport(
+                    sections = emptyList(),
+                    pointsEvents = listOf(nonPointsSeasonEvent)
+            )
+        }
+
+        assertThat(actual).all {
+            messageContains("pointsEvents")
+            messageContains("true")
+        }
+    }
+
+    @Test
+    fun `Its constructor should not throw if all pointsEvents are points`() {
+        val pointsSeasonEvent1 = mockk<SeasonEvent> {
+            every { points }.returns(true)
+        }
+
+        assertDoesNotThrow {
+            StandingsReport(
+                    sections = emptyList(),
+                    pointsEvents = listOf(pointsSeasonEvent1)
+            )
+        }
+    }
+}

--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -21,7 +21,10 @@
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-reflect</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-html-jvm</artifactId>
+        </dependency>
 
     </dependencies>
 

--- a/modules/core/src/main/kotlin/org/coner/trailer/SeasonEvent.kt
+++ b/modules/core/src/main/kotlin/org/coner/trailer/SeasonEvent.kt
@@ -9,10 +9,18 @@ data class SeasonEvent(
         val eventNumber: Int?,
         val points: Boolean,
         val seasonPointsCalculatorConfigurationModel: CalculatorConfigurationModel? = null
-) {
+) : Comparable<SeasonEvent> {
     init {
         if (points) {
             require(eventNumber != null) { "Points events require an event number" }
+        }
+    }
+
+    override fun compareTo(other: SeasonEvent): Int {
+        return if (eventNumber != null && other.eventNumber != null) {
+            eventNumber.compareTo(other.eventNumber)
+        } else {
+            event.date.compareTo(other.event.date)
         }
     }
 }

--- a/modules/core/src/main/kotlin/org/coner/trailer/seasonpoints/KotlinxHtmlStandingsReportRenderer.kt
+++ b/modules/core/src/main/kotlin/org/coner/trailer/seasonpoints/KotlinxHtmlStandingsReportRenderer.kt
@@ -35,8 +35,7 @@ class KotlinxHtmlStandingsReportRenderer {
                 colSpan = "2"
             }
             th {
-                TODO("report.pointsEventCount")
-                colSpan = report.seasonEvents.count { it.points }.toString()
+                colSpan = report.pointsEvents.size.toString()
                 scope = ThScope.colGroup
                 text("Events")
             }
@@ -44,12 +43,9 @@ class KotlinxHtmlStandingsReportRenderer {
         tr {
             th { text("Name") }
             th { text("Member #") }
-            TODO("report.seasonPointsEvents")
-            report.seasonEvents
-                    .filter { it.points }
-                    .forEach { seasonPointsEvent ->
-                        th { text(requireNotNull(seasonPointsEvent.eventNumber)) }
-                    }
+            report.pointsEvents.forEach { pointsEvents ->
+                th { text(requireNotNull(pointsEvents.eventNumber)) }
+            }
             th { text("Count") }
             th { text("Score") }
         }
@@ -66,14 +62,10 @@ class KotlinxHtmlStandingsReportRenderer {
             standing: StandingsReport.Standing) = tr {
         td { text(standing.person.name) }
         td { text(standing.person.memberId) }
-        TODO("report.seasonPointsEvents")
-        report.seasonEvents
-                .filter { it.points }
-                .forEach { seasonPointsEvent ->
-                    standingsReportSectionTableEventPointsCell(seasonPointsEvent, standing)
-                }
-        TODO("standing.count")
-        td { text(standing.eventToPoints.values.size) }
+        report.pointsEvents.forEach { pointsEvent ->
+            standingsReportSectionTableEventPointsCell(pointsEvent, standing)
+        }
+        td { text(standing.eventToPoints.size) }
         td { text(standing.score) }
     }
 

--- a/modules/core/src/main/kotlin/org/coner/trailer/seasonpoints/KotlinxHtmlStandingsReportRenderer.kt
+++ b/modules/core/src/main/kotlin/org/coner/trailer/seasonpoints/KotlinxHtmlStandingsReportRenderer.kt
@@ -32,7 +32,7 @@ class KotlinxHtmlStandingsReportRenderer {
     ) = thead {
         tr {
             th {
-                colSpan = "2"
+                colSpan = "3"
             }
             th {
                 colSpan = report.pointsEvents.size.toString()
@@ -41,6 +41,7 @@ class KotlinxHtmlStandingsReportRenderer {
             }
         }
         tr {
+            th { abbr { title = "Position"; text("Pos.") } }
             th { text("Name") }
             th { text("Member #") }
             report.pointsEvents.forEach { pointsEvents ->
@@ -60,6 +61,7 @@ class KotlinxHtmlStandingsReportRenderer {
     private fun TBODY.standingsReportSectionTableRow(
             report: StandingsReport,
             standing: StandingsReport.Standing) = tr {
+        td { text(standing.position) }
         td { text(standing.person.name) }
         td { text(standing.person.memberId) }
         report.pointsEvents.forEach { pointsEvent ->

--- a/modules/core/src/main/kotlin/org/coner/trailer/seasonpoints/KotlinxHtmlStandingsReportRenderer.kt
+++ b/modules/core/src/main/kotlin/org/coner/trailer/seasonpoints/KotlinxHtmlStandingsReportRenderer.kt
@@ -35,6 +35,7 @@ class KotlinxHtmlStandingsReportRenderer {
                 colSpan = "2"
             }
             th {
+                TODO("report.pointsEventCount")
                 colSpan = report.seasonEvents.count { it.points }.toString()
                 scope = ThScope.colGroup
                 text("Events")
@@ -43,6 +44,7 @@ class KotlinxHtmlStandingsReportRenderer {
         tr {
             th { text("Name") }
             th { text("Member #") }
+            TODO("report.seasonPointsEvents")
             report.seasonEvents
                     .filter { it.points }
                     .forEach { seasonPointsEvent ->
@@ -64,20 +66,20 @@ class KotlinxHtmlStandingsReportRenderer {
             standing: StandingsReport.Standing) = tr {
         td { text(standing.person.name) }
         td { text(standing.person.memberId) }
+        TODO("report.seasonPointsEvents")
         report.seasonEvents
                 .filter { it.points }
                 .forEach { seasonPointsEvent ->
                     standingsReportSectionTableEventPointsCell(seasonPointsEvent, standing)
                 }
+        TODO("standing.count")
         td { text(standing.eventToPoints.values.size) }
         td { text(standing.score) }
     }
 
     private fun TR.standingsReportSectionTableEventPointsCell(seasonEvent: SeasonEvent, standing: StandingsReport.Standing) = td {
-        val points = standing.eventToPoints[seasonEvent] ?: -1
-        if (points >= 0) {
-            text(points)
-        }
+        val points = standing.eventToPoints[seasonEvent] ?: return@td
+        text(points)
     }
 
 }

--- a/modules/core/src/main/kotlin/org/coner/trailer/seasonpoints/KotlinxHtmlStandingsReportRenderer.kt
+++ b/modules/core/src/main/kotlin/org/coner/trailer/seasonpoints/KotlinxHtmlStandingsReportRenderer.kt
@@ -1,0 +1,83 @@
+package org.coner.trailer.seasonpoints
+
+import kotlinx.html.*
+import kotlinx.html.stream.createHTML
+import org.coner.trailer.SeasonEvent
+
+class KotlinxHtmlStandingsReportRenderer {
+
+    fun renderContentOnly(report: StandingsReport) = createHTML().div {
+        id = "season-points-standings"
+        report.sections.forEach { section ->
+            standingsReportSection(report, section)
+        }
+    }
+
+    private fun DIV.standingsReportSection(
+            report: StandingsReport,
+            section: StandingsReport.Section
+    ) = section {
+        table {
+            caption {
+                text(section.title)
+            }
+            standingsReportSectionTableHeader(report, section)
+            standingsReportSectionTableBody(report, section)
+        }
+    }
+
+    private fun TABLE.standingsReportSectionTableHeader(
+            report: StandingsReport,
+            section: StandingsReport.Section
+    ) = thead {
+        tr {
+            th {
+                colSpan = "2"
+            }
+            th {
+                colSpan = report.seasonEvents.count { it.points }.toString()
+                scope = ThScope.colGroup
+                text("Events")
+            }
+        }
+        tr {
+            th { text("Name") }
+            th { text("Member #") }
+            report.seasonEvents
+                    .filter { it.points }
+                    .forEach { seasonPointsEvent ->
+                        th { text(requireNotNull(seasonPointsEvent.eventNumber)) }
+                    }
+            th { text("Count") }
+            th { text("Score") }
+        }
+    }
+
+    private fun TABLE.standingsReportSectionTableBody(report: StandingsReport, section: StandingsReport.Section) = tbody {
+        section.standings.forEach { standing ->
+            standingsReportSectionTableRow(report, standing)
+        }
+    }
+
+    private fun TBODY.standingsReportSectionTableRow(
+            report: StandingsReport,
+            standing: StandingsReport.Standing) = tr {
+        td { text(standing.person.name) }
+        td { text(standing.person.memberId) }
+        report.seasonEvents
+                .filter { it.points }
+                .forEach { seasonPointsEvent ->
+                    standingsReportSectionTableEventPointsCell(seasonPointsEvent, standing)
+                }
+        td { text(standing.eventToPoints.values.size) }
+        td { text(standing.score) }
+    }
+
+    private fun TR.standingsReportSectionTableEventPointsCell(seasonEvent: SeasonEvent, standing: StandingsReport.Standing) = td {
+        val points = standing.eventToPoints[seasonEvent] ?: -1
+        if (points >= 0) {
+            text(points)
+        }
+    }
+
+}

--- a/modules/core/src/main/kotlin/org/coner/trailer/seasonpoints/KotlinxHtmlStandingsReportRenderer.kt
+++ b/modules/core/src/main/kotlin/org/coner/trailer/seasonpoints/KotlinxHtmlStandingsReportRenderer.kt
@@ -11,6 +11,7 @@ class KotlinxHtmlStandingsReportRenderer {
         report.sections.forEach { section ->
             standingsReportSection(report, section)
         }
+        legend()
     }
 
     private fun DIV.standingsReportSection(
@@ -61,7 +62,12 @@ class KotlinxHtmlStandingsReportRenderer {
     private fun TBODY.standingsReportSectionTableRow(
             report: StandingsReport,
             standing: StandingsReport.Standing) = tr {
-        td { text(standing.position) }
+        td {
+            text(standing.position)
+            if (standing.tie) {
+                a("#legend-tie") { text("*") }
+            }
+        }
         td { text(standing.person.name) }
         td { text(standing.person.memberId) }
         report.pointsEvents.forEach { pointsEvent ->
@@ -74,6 +80,16 @@ class KotlinxHtmlStandingsReportRenderer {
     private fun TR.standingsReportSectionTableEventPointsCell(seasonEvent: SeasonEvent, standing: StandingsReport.Standing) = td {
         val points = standing.eventToPoints[seasonEvent] ?: return@td
         text(points)
+    }
+
+    private fun DIV.legend() = dl {
+        dt {
+            id = "legend-tie"
+            text("*")
+        }
+        dd {
+            text("Tie")
+        }
     }
 
 }

--- a/modules/core/src/main/kotlin/org/coner/trailer/seasonpoints/StandingsReport.kt
+++ b/modules/core/src/main/kotlin/org/coner/trailer/seasonpoints/StandingsReport.kt
@@ -2,9 +2,11 @@ package org.coner.trailer.seasonpoints
 
 import org.coner.trailer.Person
 import org.coner.trailer.SeasonEvent
+import java.util.*
 
 class StandingsReport(
-        val sections: List<Section>
+        val sections: List<Section>,
+        val seasonEvents: List<SeasonEvent>
 ) {
     class Section(
             val title: String,
@@ -14,7 +16,7 @@ class StandingsReport(
     class Standing(
             val position: Int,
             val person: Person,
-            val eventToPoints: Map<SeasonEvent, Int>,
+            val eventToPoints: SortedMap<SeasonEvent, Int>,
             val score: Int,
             val tie: Boolean
     )

--- a/modules/core/src/main/kotlin/org/coner/trailer/seasonpoints/StandingsReport.kt
+++ b/modules/core/src/main/kotlin/org/coner/trailer/seasonpoints/StandingsReport.kt
@@ -6,8 +6,13 @@ import java.util.*
 
 class StandingsReport(
         val sections: List<Section>,
-        val seasonEvents: List<SeasonEvent>
+        val pointsEvents: List<SeasonEvent>
 ) {
+
+    init {
+        require(pointsEvents.all { it.points }) { "pointsEvents must contain only SeasonEvent instances with points==true" }
+    }
+
     class Section(
             val title: String,
             val standings: List<Standing>
@@ -19,6 +24,8 @@ class StandingsReport(
             val eventToPoints: SortedMap<SeasonEvent, Int>,
             val score: Int,
             val tie: Boolean
-    )
+    ) {
+        val count = eventToPoints.size
+    }
 
 }

--- a/modules/core/src/main/kotlin/org/coner/trailer/seasonpoints/StandingsReportCreator.kt
+++ b/modules/core/src/main/kotlin/org/coner/trailer/seasonpoints/StandingsReportCreator.kt
@@ -101,7 +101,7 @@ class StandingsReportCreator {
                                 position = checkNotNull(accumulator.position),
                                 tie = accumulator.tie,
                                 person = accumulator.person,
-                                eventToPoints = accumulator.eventToPoints.toMap(),
+                                eventToPoints = accumulator.eventToPoints.toSortedMap(),
                                 score = accumulator.score
                         )
                     }.toList()

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.version>1.3.72</kotlin.version>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
+        <kotlinx.html.version>0.7.1</kotlinx.html.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
         <junit.jupiter.version>5.6.2</junit.jupiter.version>
@@ -36,6 +37,11 @@
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-reflect</artifactId>
                 <version>${kotlin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlinx</groupId>
+                <artifactId>kotlinx-html-jvm</artifactId>
+                <version>${kotlinx.html.version}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <junit.jupiter.version>5.6.2</junit.jupiter.version>
         <assertk.version>0.22</assertk.version>
         <mockk.version>1.10.0</mockk.version>
+        <jsoup.version>1.13.1</jsoup.version>
     </properties>
 
     <dependencyManagement>
@@ -60,6 +61,12 @@
                 <groupId>io.mockk</groupId>
                 <artifactId>mockk</artifactId>
                 <version>${mockk.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jsoup</groupId>
+                <artifactId>jsoup</artifactId>
+                <version>${jsoup.version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
Switching the approach away from including the HTML report in the core module to leaving it to applications. So why the pull request including it into the core module? So it'll be easier to recycle it into the CLI app, which is the first application where it will be implemented, and whose concerns are overwhelmingly weighed in the design of this report. And because of inclusion of additional test fixtures, particularly related to tie-breaking cases.