### PR TITLE
Ranking sorts, closes #21

### DIFF
--- a/modules/cli/pom.xml
+++ b/modules/cli/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>coner-trailer-cli</artifactId>
 
     <properties>
-        <clikt.version>2.8.0</clikt.version>
+        <clikt.version>3.0.0</clikt.version>
         <appdirs.version>1.2.0</appdirs.version>
     </properties>
 
@@ -47,9 +47,10 @@
             <artifactId>kodein-di-jvm</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.ajalt</groupId>
+            <groupId>com.github.ajalt.clikt</groupId>
             <artifactId>clikt</artifactId>
             <version>${clikt.version}</version>
+            <type>pom</type>
         </dependency>
         <dependency>
             <groupId>net.harawata</groupId>

--- a/modules/cli/pom.xml
+++ b/modules/cli/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>coner-trailer-cli</artifactId>
 
     <properties>
-        <clikt.version>3.0.0</clikt.version>
+        <clikt.version>3.0.1</clikt.version>
         <appdirs.version>1.2.0</appdirs.version>
     </properties>
 
@@ -48,9 +48,8 @@
         </dependency>
         <dependency>
             <groupId>com.github.ajalt.clikt</groupId>
-            <artifactId>clikt</artifactId>
+            <artifactId>clikt-jvm</artifactId>
             <version>${clikt.version}</version>
-            <type>pom</type>
         </dependency>
         <dependency>
             <groupId>net.harawata</groupId>

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/config/ConfigCommand.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/config/ConfigCommand.kt
@@ -1,6 +1,7 @@
-package org.coner.trailer.cli.command
+package org.coner.trailer.cli.command.config
 
 import com.github.ajalt.clikt.core.CliktCommand
+import org.coner.trailer.cli.command.RootCommand
 
 class ConfigCommand() : CliktCommand(
         name = "config",

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/config/ConfigDatabaseCommand.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/config/ConfigDatabaseCommand.kt
@@ -1,4 +1,4 @@
-package org.coner.trailer.cli.command
+package org.coner.trailer.cli.command.config
 
 import com.github.ajalt.clikt.core.CliktCommand
 

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/config/ConfigDatabaseGetCommand.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/config/ConfigDatabaseGetCommand.kt
@@ -1,4 +1,4 @@
-package org.coner.trailer.cli.command
+package org.coner.trailer.cli.command.config
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.context

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/config/ConfigDatabaseListCommand.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/config/ConfigDatabaseListCommand.kt
@@ -1,4 +1,4 @@
-package org.coner.trailer.cli.command
+package org.coner.trailer.cli.command.config
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.context

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/config/ConfigDatabaseRemoveCommand.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/config/ConfigDatabaseRemoveCommand.kt
@@ -1,4 +1,4 @@
-package org.coner.trailer.cli.command
+package org.coner.trailer.cli.command.config
 
 import com.github.ajalt.clikt.core.Abort
 import com.github.ajalt.clikt.core.CliktCommand
@@ -8,11 +8,16 @@ import com.github.ajalt.clikt.parameters.types.choice
 import org.coner.trailer.cli.io.ConfigurationService
 import org.coner.trailer.cli.io.DatabaseConfiguration
 
-class ConfigDatabaseSetDefaultCommand(
+class ConfigDatabaseRemoveCommand(
         private val config: ConfigurationService
 ) : CliktCommand(
-        name = "set-default",
-        help = "Set named database to default"
+        name = "remove",
+        help = """
+                Remove a database from the CLI app's config file.
+                
+                This is a non-destructive operation -- you can always add the database again. This will not affect the
+                database itself.
+            """.trimIndent()
 ) {
 
     val dbConfig: DatabaseConfiguration by option(names = *arrayOf("--name"))
@@ -21,9 +26,6 @@ class ConfigDatabaseSetDefaultCommand(
 
     override fun run() {
         if (dbConfig == config.noDatabase) throw Abort()
-        val asDefault = dbConfig.copy(
-                default = true
-        )
-        config.configureDatabase(asDefault)
+        config.removeDatabase(dbConfig)
     }
 }

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/config/ConfigDatabaseSetCommand.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/config/ConfigDatabaseSetCommand.kt
@@ -1,4 +1,4 @@
-package org.coner.trailer.cli.command
+package org.coner.trailer.cli.command.config
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.context

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/config/ConfigDatabaseSetDefaultCommand.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/config/ConfigDatabaseSetDefaultCommand.kt
@@ -1,4 +1,4 @@
-package org.coner.trailer.cli.command
+package org.coner.trailer.cli.command.config
 
 import com.github.ajalt.clikt.core.Abort
 import com.github.ajalt.clikt.core.CliktCommand
@@ -8,16 +8,11 @@ import com.github.ajalt.clikt.parameters.types.choice
 import org.coner.trailer.cli.io.ConfigurationService
 import org.coner.trailer.cli.io.DatabaseConfiguration
 
-class ConfigDatabaseRemoveCommand(
+class ConfigDatabaseSetDefaultCommand(
         private val config: ConfigurationService
 ) : CliktCommand(
-        name = "remove",
-        help = """
-                Remove a database from the CLI app's config file.
-                
-                This is a non-destructive operation -- you can always add the database again. This will not affect the
-                database itself.
-            """.trimIndent()
+        name = "set-default",
+        help = "Set named database to default"
 ) {
 
     val dbConfig: DatabaseConfiguration by option(names = *arrayOf("--name"))
@@ -26,6 +21,9 @@ class ConfigDatabaseRemoveCommand(
 
     override fun run() {
         if (dbConfig == config.noDatabase) throw Abort()
-        config.removeDatabase(dbConfig)
+        val asDefault = dbConfig.copy(
+                default = true
+        )
+        config.configureDatabase(asDefault)
     }
 }

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/participanteventresultpointscalculator/ParticipantEventResultPointsCalculatorAddCommand.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/participanteventresultpointscalculator/ParticipantEventResultPointsCalculatorAddCommand.kt
@@ -1,4 +1,4 @@
-package org.coner.trailer.cli.command
+package org.coner.trailer.cli.command.participanteventresultpointscalculator
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.context

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/participanteventresultpointscalculator/ParticipantEventResultPointsCalculatorAddCommand.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/participanteventresultpointscalculator/ParticipantEventResultPointsCalculatorAddCommand.kt
@@ -38,7 +38,6 @@ class ParticipantEventResultPointsCalculatorAddCommand(
             .default(UUID.randomUUID())
     private val name: String by option()
             .required()
-            .validate { require(service.hasNewName(it)) { "Name already exists: $it" } }
     private val positionToPoints: List<Pair<Int, Int>> by option()
             .int()
             .pair()

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/participanteventresultpointscalculator/ParticipantEventResultPointsCalculatorAddCommand.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/participanteventresultpointscalculator/ParticipantEventResultPointsCalculatorAddCommand.kt
@@ -8,6 +8,7 @@ import com.github.ajalt.clikt.parameters.options.*
 import com.github.ajalt.clikt.parameters.types.int
 import org.coner.trailer.cli.util.clikt.toUuid
 import org.coner.trailer.cli.view.ParticipantEventResultPointsCalculatorView
+import org.coner.trailer.io.constraint.ParticipantEventResultPointsCalculatorPersistConstraints
 import org.coner.trailer.io.service.ParticipantEventResultPointsCalculatorService
 import org.coner.trailer.seasonpoints.ParticipantEventResultPointsCalculator
 import org.kodein.di.DI
@@ -30,6 +31,7 @@ class ParticipantEventResultPointsCalculatorAddCommand(
     }
 
     override val di: DI by findOrSetObject { di }
+    private val constraints: ParticipantEventResultPointsCalculatorPersistConstraints by instance()
     private val service: ParticipantEventResultPointsCalculatorService by instance()
     private val view: ParticipantEventResultPointsCalculatorView by instance()
 
@@ -38,6 +40,10 @@ class ParticipantEventResultPointsCalculatorAddCommand(
             .default(UUID.randomUUID())
     private val name: String by option()
             .required()
+            .validate {
+                if (!constraints.hasUniqueName(id, it))
+                    fail("Name must be unique")
+            }
     private val positionToPoints: List<Pair<Int, Int>> by option()
             .int()
             .pair()

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/participanteventresultpointscalculator/ParticipantEventResultPointsCalculatorCommand.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/participanteventresultpointscalculator/ParticipantEventResultPointsCalculatorCommand.kt
@@ -1,4 +1,4 @@
-package org.coner.trailer.cli.command
+package org.coner.trailer.cli.command.participanteventresultpointscalculator
 
 import com.github.ajalt.clikt.core.CliktCommand
 

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/participanteventresultpointscalculator/ParticipantEventResultPointsCalculatorDeleteCommand.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/participanteventresultpointscalculator/ParticipantEventResultPointsCalculatorDeleteCommand.kt
@@ -1,4 +1,4 @@
-package org.coner.trailer.cli.command
+package org.coner.trailer.cli.command.participanteventresultpointscalculator
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.context

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/participanteventresultpointscalculator/ParticipantEventResultPointsCalculatorGetCommand.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/participanteventresultpointscalculator/ParticipantEventResultPointsCalculatorGetCommand.kt
@@ -1,4 +1,4 @@
-package org.coner.trailer.cli.command
+package org.coner.trailer.cli.command.participanteventresultpointscalculator
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.context

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/participanteventresultpointscalculator/ParticipantEventResultPointsCalculatorListCommand.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/participanteventresultpointscalculator/ParticipantEventResultPointsCalculatorListCommand.kt
@@ -1,4 +1,4 @@
-package org.coner.trailer.cli.command
+package org.coner.trailer.cli.command.participanteventresultpointscalculator
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.context

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/participanteventresultpointscalculator/ParticipantEventResultPointsCalculatorSetCommand.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/participanteventresultpointscalculator/ParticipantEventResultPointsCalculatorSetCommand.kt
@@ -1,4 +1,4 @@
-package org.coner.trailer.cli.command
+package org.coner.trailer.cli.command.participanteventresultpointscalculator
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.context

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/participanteventresultpointscalculator/ParticipantEventResultPointsCalculatorSetCommand.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/participanteventresultpointscalculator/ParticipantEventResultPointsCalculatorSetCommand.kt
@@ -40,7 +40,6 @@ class ParticipantEventResultPointsCalculatorSetCommand(
             .convert { toUuid(it) }
 
     private val name: String? by option()
-            .validate { require(service.hasNewName(it)) { "Name already exists: $it" } }
 
     private val positionToPoints: List<Pair<Int, Int>> by option()
             .int()

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortAddCommand.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortAddCommand.kt
@@ -7,7 +7,9 @@ import com.github.ajalt.clikt.output.CliktConsole
 import com.github.ajalt.clikt.parameters.groups.*
 import com.github.ajalt.clikt.parameters.options.*
 import org.coner.trailer.cli.util.clikt.toUuid
+import org.coner.trailer.cli.view.RankingSortView
 import org.coner.trailer.io.service.RankingSortService
+import org.coner.trailer.seasonpoints.RankingSort
 import org.kodein.di.DI
 import org.kodein.di.DIAware
 import org.kodein.di.instance
@@ -28,6 +30,7 @@ class RankingSortAddCommand(
 
     override val di: DI by findOrSetObject { di }
     private val service: RankingSortService by instance()
+    private val view: RankingSortView by instance()
 
     private val id: UUID by option(hidden = true)
             .convert { toUuid(it) }
@@ -43,7 +46,13 @@ class RankingSortAddCommand(
             .required()
 
     override fun run() {
-
+        val create = RankingSort(
+                id = id,
+                name = name,
+                steps = listOf(step.step)
+        )
+        service.create(create)
+        echo(view.render(create))
     }
 
 

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortAddCommand.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortAddCommand.kt
@@ -7,9 +7,10 @@ import com.github.ajalt.clikt.output.CliktConsole
 import com.github.ajalt.clikt.parameters.groups.*
 import com.github.ajalt.clikt.parameters.options.*
 import org.coner.trailer.cli.util.clikt.toUuid
-import org.coner.trailer.seasonpoints.RankingSort
+import org.coner.trailer.io.service.RankingSortService
 import org.kodein.di.DI
 import org.kodein.di.DIAware
+import org.kodein.di.instance
 import java.util.*
 
 class RankingSortAddCommand(
@@ -26,23 +27,23 @@ class RankingSortAddCommand(
     }
 
     override val di: DI by findOrSetObject { di }
+    private val service: RankingSortService by instance()
 
     private val id: UUID by option(hidden = true)
             .convert { toUuid(it) }
             .default(UUID.randomUUID())
     private val name: String by option()
             .required()
-    sealed class StepOptionGroup : OptionGroup() {
-        object ScoreDescending : StepOptionGroup()
-    }
-    private val step0: StepOptionGroup by option()
-            .groupChoice(
-                    "--score-descending" to StepOptionGroup.ScoreDescending
+    private val step: RankingSortStepOptionGroup by option()
+            .groupSwitch(
+                    "--score-descending" to RankingSortStepOptionGroup.ScoreDescending,
+                    "--position-finish-count-descending" to RankingSortStepOptionGroup.PositionFinishCountDescending(),
+                    "--average-margin-of-victory-descending" to RankingSortStepOptionGroup.AverageMarginOfVictoryDescending
             )
             .required()
 
     override fun run() {
-        TODO("Not yet implemented")
+
     }
 
 

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortAddCommand.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortAddCommand.kt
@@ -8,6 +8,7 @@ import com.github.ajalt.clikt.parameters.groups.*
 import com.github.ajalt.clikt.parameters.options.*
 import org.coner.trailer.cli.util.clikt.toUuid
 import org.coner.trailer.cli.view.RankingSortView
+import org.coner.trailer.io.constraint.RankingSortPersistConstraints
 import org.coner.trailer.io.service.RankingSortService
 import org.coner.trailer.seasonpoints.RankingSort
 import org.kodein.di.DI
@@ -29,6 +30,7 @@ class RankingSortAddCommand(
     }
 
     override val di: DI by findOrSetObject { di }
+    private val constraints: RankingSortPersistConstraints by instance()
     private val service: RankingSortService by instance()
     private val view: RankingSortView by instance()
 
@@ -37,6 +39,10 @@ class RankingSortAddCommand(
             .default(UUID.randomUUID())
     private val name: String by option()
             .required()
+            .validate {
+                if (!constraints.hasUniqueName(id, it))
+                    fail("Name must be unique")
+            }
     private val step: RankingSortStepOptionGroup by option()
             .groupSwitch(
                     "--score-descending" to RankingSortStepOptionGroup.ScoreDescending,

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortAddCommand.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortAddCommand.kt
@@ -4,9 +4,7 @@ import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.context
 import com.github.ajalt.clikt.core.findOrSetObject
 import com.github.ajalt.clikt.output.CliktConsole
-import com.github.ajalt.clikt.parameters.groups.OptionGroup
-import com.github.ajalt.clikt.parameters.groups.groupChoice
-import com.github.ajalt.clikt.parameters.groups.groupSwitch
+import com.github.ajalt.clikt.parameters.groups.*
 import com.github.ajalt.clikt.parameters.options.*
 import org.coner.trailer.cli.util.clikt.toUuid
 import org.coner.trailer.seasonpoints.RankingSort
@@ -32,14 +30,16 @@ class RankingSortAddCommand(
     private val id: UUID by option(hidden = true)
             .convert { toUuid(it) }
             .default(UUID.randomUUID())
+    private val name: String by option()
+            .required()
     sealed class StepOptionGroup : OptionGroup() {
         object ScoreDescending : StepOptionGroup()
     }
-//    private val steps: List<RankingSort.Step> by option()
-//            .multiple()
-//            .switch(
-//                    "--score-descending" to StepOptionGroup.ScoreDescending
-//            )
+    private val step0: StepOptionGroup by option()
+            .groupChoice(
+                    "--score-descending" to StepOptionGroup.ScoreDescending
+            )
+            .required()
 
     override fun run() {
         TODO("Not yet implemented")

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortAddCommand.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortAddCommand.kt
@@ -1,0 +1,49 @@
+package org.coner.trailer.cli.command.rankingsort
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.context
+import com.github.ajalt.clikt.core.findOrSetObject
+import com.github.ajalt.clikt.output.CliktConsole
+import com.github.ajalt.clikt.parameters.groups.OptionGroup
+import com.github.ajalt.clikt.parameters.groups.groupChoice
+import com.github.ajalt.clikt.parameters.groups.groupSwitch
+import com.github.ajalt.clikt.parameters.options.*
+import org.coner.trailer.cli.util.clikt.toUuid
+import org.coner.trailer.seasonpoints.RankingSort
+import org.kodein.di.DI
+import org.kodein.di.DIAware
+import java.util.*
+
+class RankingSortAddCommand(
+        di: DI,
+        useConsole: CliktConsole
+) : CliktCommand(
+        name = "add"
+), DIAware {
+
+    init {
+        context {
+            console = useConsole
+        }
+    }
+
+    override val di: DI by findOrSetObject { di }
+
+    private val id: UUID by option(hidden = true)
+            .convert { toUuid(it) }
+            .default(UUID.randomUUID())
+    sealed class StepOptionGroup : OptionGroup() {
+        object ScoreDescending : StepOptionGroup()
+    }
+//    private val steps: List<RankingSort.Step> by option()
+//            .multiple()
+//            .switch(
+//                    "--score-descending" to StepOptionGroup.ScoreDescending
+//            )
+
+    override fun run() {
+        TODO("Not yet implemented")
+    }
+
+
+}

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortCommand.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortCommand.kt
@@ -1,0 +1,8 @@
+package org.coner.trailer.cli.command.rankingsort
+
+import com.github.ajalt.clikt.core.CliktCommand
+
+class RankingSortCommand : CliktCommand() {
+
+    override fun run() = Unit
+}

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortDeleteCommand.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortDeleteCommand.kt
@@ -1,0 +1,42 @@
+package org.coner.trailer.cli.command.rankingsort
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.context
+import com.github.ajalt.clikt.core.findOrSetObject
+import com.github.ajalt.clikt.output.CliktConsole
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.arguments.convert
+import org.coner.trailer.cli.util.clikt.toUuid
+import org.coner.trailer.cli.view.RankingSortView
+import org.coner.trailer.io.service.RankingSortService
+import org.kodein.di.DI
+import org.kodein.di.DIAware
+import org.kodein.di.instance
+import java.util.*
+
+class RankingSortDeleteCommand(
+        di: DI,
+        useConsole: CliktConsole
+) : CliktCommand(
+        name = "delete",
+        help = "Delete a ranking sort"
+), DIAware {
+
+    init {
+        context {
+            console = useConsole
+        }
+    }
+
+    override val di: DI by findOrSetObject { di }
+
+    private val service: RankingSortService by instance()
+
+    private val id: UUID by argument()
+            .convert { toUuid(it) }
+
+    override fun run() {
+        val delete = service.findById(id)
+        service.delete(delete)
+    }
+}

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortGetCommand.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortGetCommand.kt
@@ -1,4 +1,4 @@
-package org.coner.trailer.cli.command.participanteventresultpointscalculator
+package org.coner.trailer.cli.command.rankingsort
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.context
@@ -10,19 +10,19 @@ import com.github.ajalt.clikt.parameters.groups.single
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.option
 import org.coner.trailer.cli.util.clikt.toUuid
-import org.coner.trailer.cli.view.ParticipantEventResultPointsCalculatorView
-import org.coner.trailer.io.service.ParticipantEventResultPointsCalculatorService
+import org.coner.trailer.cli.view.RankingSortView
+import org.coner.trailer.io.service.RankingSortService
 import org.kodein.di.DI
 import org.kodein.di.DIAware
 import org.kodein.di.instance
 import java.util.*
 
-class ParticipantEventResultPointsCalculatorGetCommand(
+class RankingSortGetCommand(
         di: DI,
         useConsole: CliktConsole
 ) : CliktCommand(
         name = "get",
-        help = "Get a participant event result points calculator"
+        help = "Get a ranking sort"
 ), DIAware {
 
     init {
@@ -32,30 +32,26 @@ class ParticipantEventResultPointsCalculatorGetCommand(
     }
 
     override val di: DI by findOrSetObject { di }
-    private val service: ParticipantEventResultPointsCalculatorService by instance()
-    private val view: ParticipantEventResultPointsCalculatorView by instance()
+
+    private val service: RankingSortService by instance()
+    private val view: RankingSortView by instance()
 
     sealed class Query {
         data class ById(val id: UUID) : Query()
         data class ByName(val name: String) : Query()
     }
-
     private val query: Query by mutuallyExclusiveOptions(
             option("--id", help = "Get by ID")
-                    .convert {
-                        Query.ById(toUuid(it))
-                    },
+                    .convert { Query.ById(id = toUuid(it)) },
             option("--name", help = "Get by name")
-                    .convert {
-                        Query.ByName(it)
-                    }
+                    .convert { Query.ByName(name = it) }
     ).single().required()
 
     override fun run() {
-        val read = when (val query = query) {
+        val get = when(val query = this.query) {
             is Query.ById -> service.findById(query.id)
             is Query.ByName -> service.findByName(query.name)
         }
-        echo(view.render(read ?: return))
+        echo(view.render(get ?: return))
     }
 }

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortListCommand.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortListCommand.kt
@@ -1,0 +1,35 @@
+package org.coner.trailer.cli.command.rankingsort
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.context
+import com.github.ajalt.clikt.core.findOrSetObject
+import com.github.ajalt.clikt.output.CliktConsole
+import org.coner.trailer.cli.view.RankingSortView
+import org.coner.trailer.io.service.RankingSortService
+import org.kodein.di.DI
+import org.kodein.di.DIAware
+import org.kodein.di.instance
+
+class RankingSortListCommand(
+        di: DI,
+        useConsole: CliktConsole
+) : CliktCommand(
+        name = "list",
+        help = "List ranking sorts"
+), DIAware {
+
+    init {
+        context {
+            console = useConsole
+        }
+    }
+
+    override val di: DI by findOrSetObject { di }
+
+    private val service: RankingSortService by instance()
+    private val view: RankingSortView by instance()
+
+    override fun run() {
+        echo(view.render(service.list()))
+    }
+}

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortSetCommand.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortSetCommand.kt
@@ -1,0 +1,53 @@
+package org.coner.trailer.cli.command.rankingsort
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.context
+import com.github.ajalt.clikt.core.findOrSetObject
+import com.github.ajalt.clikt.output.CliktConsole
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.arguments.convert
+import com.github.ajalt.clikt.parameters.options.option
+import org.coner.trailer.cli.util.clikt.toUuid
+import org.coner.trailer.cli.view.RankingSortView
+import org.coner.trailer.io.service.RankingSortService
+import org.coner.trailer.seasonpoints.RankingSort
+import org.kodein.di.DI
+import org.kodein.di.DIAware
+import org.kodein.di.instance
+import java.util.*
+
+class RankingSortSetCommand(
+        di: DI,
+        useConsole: CliktConsole
+) : CliktCommand(
+        name = "set",
+        help = "Set a ranking sort"
+), DIAware {
+
+    init {
+        context {
+            console = useConsole
+        }
+    }
+
+    override val di: DI by findOrSetObject { di }
+
+    private val service: RankingSortService by instance()
+    private val view: RankingSortView by instance()
+
+    private val id: UUID by argument()
+            .convert { toUuid(it) }
+    private val name: String? by option()
+    private val step: RankingSortStepOptionGroup? by rankingSortStepOptions()
+
+    override fun run() {
+        val old = service.findById(id)
+        val update = RankingSort(
+                id = old.id,
+                name = name ?: old.name,
+                steps = step?.let { listOf(it.step) } ?: old.steps
+        )
+        service.update(update)
+        echo(view.render(update))
+    }
+}

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortStepOptionGroup.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortStepOptionGroup.kt
@@ -11,7 +11,7 @@ sealed class RankingSortStepOptionGroup : OptionGroup() {
     abstract val step: RankingSort.Step
     object ScoreDescending : RankingSortStepOptionGroup() {
         override val step: RankingSort.Step
-            get() = RankingSort.Step.ScoreDescending
+            get() = RankingSort.Step.ScoreDescending()
     }
     class PositionFinishCountDescending : RankingSortStepOptionGroup() {
         val position: Int by option()
@@ -24,6 +24,6 @@ sealed class RankingSortStepOptionGroup : OptionGroup() {
     }
     object AverageMarginOfVictoryDescending : RankingSortStepOptionGroup() {
         override val step: RankingSort.Step
-            get() = RankingSort.Step.AverageMarginOfVictoryDescending
+            get() = RankingSort.Step.AverageMarginOfVictoryDescending(index = 0)
     }
 }

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortStepOptionGroup.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortStepOptionGroup.kt
@@ -1,10 +1,19 @@
 package org.coner.trailer.cli.command.rankingsort
 
+import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.groups.OptionGroup
+import com.github.ajalt.clikt.parameters.groups.groupSwitch
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.int
 import org.coner.trailer.seasonpoints.RankingSort
+
+fun CliktCommand.rankingSortStepOptions() = option()
+        .groupSwitch(
+                "--score-descending" to RankingSortStepOptionGroup.ScoreDescending,
+                "--position-finish-count-descending" to RankingSortStepOptionGroup.PositionFinishCountDescending(),
+                "--average-margin-of-victory-descending" to RankingSortStepOptionGroup.AverageMarginOfVictoryDescending
+        )
 
 sealed class RankingSortStepOptionGroup : OptionGroup() {
 

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortStepOptionGroup.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortStepOptionGroup.kt
@@ -1,0 +1,16 @@
+package org.coner.trailer.cli.command.rankingsort
+
+import com.github.ajalt.clikt.parameters.groups.OptionGroup
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.types.int
+
+sealed class RankingSortStepOptionGroup : OptionGroup() {
+    object ScoreDescending : RankingSortStepOptionGroup()
+    class PositionFinishCountDescending : RankingSortStepOptionGroup() {
+        val position: Int by option()
+                .int()
+                .required()
+    }
+    object AverageMarginOfVictoryDescending : RankingSortStepOptionGroup()
+}

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortStepOptionGroup.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortStepOptionGroup.kt
@@ -4,13 +4,26 @@ import com.github.ajalt.clikt.parameters.groups.OptionGroup
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.int
+import org.coner.trailer.seasonpoints.RankingSort
 
 sealed class RankingSortStepOptionGroup : OptionGroup() {
-    object ScoreDescending : RankingSortStepOptionGroup()
+
+    abstract val step: RankingSort.Step
+    object ScoreDescending : RankingSortStepOptionGroup() {
+        override val step: RankingSort.Step
+            get() = RankingSort.Step.ScoreDescending
+    }
     class PositionFinishCountDescending : RankingSortStepOptionGroup() {
         val position: Int by option()
                 .int()
                 .required()
+        override val step: RankingSort.Step
+            get() = RankingSort.Step.PositionFinishCountDescending(
+                    position = position
+            )
     }
-    object AverageMarginOfVictoryDescending : RankingSortStepOptionGroup()
+    object AverageMarginOfVictoryDescending : RankingSortStepOptionGroup() {
+        override val step: RankingSort.Step
+            get() = RankingSort.Step.AverageMarginOfVictoryDescending
+    }
 }

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortStepsAppendCommand.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortStepsAppendCommand.kt
@@ -4,11 +4,11 @@ import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.context
 import com.github.ajalt.clikt.core.findOrSetObject
 import com.github.ajalt.clikt.output.CliktConsole
-import com.github.ajalt.clikt.parameters.groups.*
-import com.github.ajalt.clikt.parameters.options.*
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.arguments.convert
+import com.github.ajalt.clikt.parameters.groups.required
 import org.coner.trailer.cli.util.clikt.toUuid
 import org.coner.trailer.cli.view.RankingSortView
-import org.coner.trailer.io.constraint.RankingSortPersistConstraints
 import org.coner.trailer.io.service.RankingSortService
 import org.coner.trailer.seasonpoints.RankingSort
 import org.kodein.di.DI
@@ -16,11 +16,12 @@ import org.kodein.di.DIAware
 import org.kodein.di.instance
 import java.util.*
 
-class RankingSortAddCommand(
+class RankingSortStepsAppendCommand(
         di: DI,
         useConsole: CliktConsole
 ) : CliktCommand(
-        name = "add"
+        name = "steps-append",
+        help = "Append a step to a Ranking Sort"
 ), DIAware {
 
     init {
@@ -30,31 +31,23 @@ class RankingSortAddCommand(
     }
 
     override val di: DI by findOrSetObject { di }
-    private val constraints: RankingSortPersistConstraints by instance()
     private val service: RankingSortService by instance()
     private val view: RankingSortView by instance()
 
-    private val id: UUID by option(hidden = true)
+    private val id: UUID by argument()
             .convert { toUuid(it) }
-            .default(UUID.randomUUID())
-    private val name: String by option()
-            .required()
-            .validate {
-                if (!constraints.hasUniqueName(id, it))
-                    fail("Name must be unique")
-            }
+
     private val step: RankingSortStepOptionGroup by rankingSortStepOptions()
             .required()
 
     override fun run() {
-        val create = RankingSort(
-                id = id,
-                name = name,
-                steps = listOf(step.step)
+        val rankingSort: RankingSort = service.findById(id)
+        val update = rankingSort.copy(
+                steps = rankingSort.steps.toMutableList().apply {
+                    add(step.step)
+                }
         )
-        service.create(create)
-        echo(view.render(create))
+        service.update(update)
+        echo(view.render(update))
     }
-
-
 }

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/di/CliktModule.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/di/CliktModule.kt
@@ -5,6 +5,8 @@ import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.output.CliktConsole
 import com.github.ajalt.clikt.output.defaultCliktConsole
 import org.coner.trailer.cli.command.*
+import org.coner.trailer.cli.command.config.*
+import org.coner.trailer.cli.command.participanteventresultpointscalculator.*
 import org.kodein.di.DI
 import org.kodein.di.bind
 import org.kodein.di.instance

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/di/CliktModule.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/di/CliktModule.kt
@@ -9,6 +9,7 @@ import org.coner.trailer.cli.command.config.*
 import org.coner.trailer.cli.command.participanteventresultpointscalculator.*
 import org.coner.trailer.cli.command.rankingsort.RankingSortAddCommand
 import org.coner.trailer.cli.command.rankingsort.RankingSortCommand
+import org.coner.trailer.cli.command.rankingsort.RankingSortStepsAppendCommand
 import org.kodein.di.DI
 import org.kodein.di.bind
 import org.kodein.di.instance
@@ -83,6 +84,10 @@ val cliktModule = DI.Module("clikt") {
     bind<RankingSortCommand>() with singleton { RankingSortCommand()
             .subcommands(
                     RankingSortAddCommand(
+                            di = di,
+                            useConsole = instance()
+                    ),
+                    RankingSortStepsAppendCommand(
                             di = di,
                             useConsole = instance()
                     )

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/di/CliktModule.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/di/CliktModule.kt
@@ -100,6 +100,10 @@ val cliktModule = DI.Module("clikt") {
                     RankingSortSetCommand(
                             di = di,
                             useConsole = instance()
+                    ),
+                    RankingSortDeleteCommand(
+                            di = di,
+                            useConsole = instance()
                     )
             )
     }

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/di/CliktModule.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/di/CliktModule.kt
@@ -7,10 +7,7 @@ import com.github.ajalt.clikt.output.defaultCliktConsole
 import org.coner.trailer.cli.command.*
 import org.coner.trailer.cli.command.config.*
 import org.coner.trailer.cli.command.participanteventresultpointscalculator.*
-import org.coner.trailer.cli.command.rankingsort.RankingSortAddCommand
-import org.coner.trailer.cli.command.rankingsort.RankingSortCommand
-import org.coner.trailer.cli.command.rankingsort.RankingSortListCommand
-import org.coner.trailer.cli.command.rankingsort.RankingSortStepsAppendCommand
+import org.coner.trailer.cli.command.rankingsort.*
 import org.kodein.di.DI
 import org.kodein.di.bind
 import org.kodein.di.instance
@@ -93,6 +90,10 @@ val cliktModule = DI.Module("clikt") {
                             useConsole = instance()
                     ),
                     RankingSortListCommand(
+                            di = di,
+                            useConsole = instance()
+                    ),
+                    RankingSortGetCommand(
                             di = di,
                             useConsole = instance()
                     )

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/di/CliktModule.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/di/CliktModule.kt
@@ -9,6 +9,7 @@ import org.coner.trailer.cli.command.config.*
 import org.coner.trailer.cli.command.participanteventresultpointscalculator.*
 import org.coner.trailer.cli.command.rankingsort.RankingSortAddCommand
 import org.coner.trailer.cli.command.rankingsort.RankingSortCommand
+import org.coner.trailer.cli.command.rankingsort.RankingSortListCommand
 import org.coner.trailer.cli.command.rankingsort.RankingSortStepsAppendCommand
 import org.kodein.di.DI
 import org.kodein.di.bind
@@ -88,6 +89,10 @@ val cliktModule = DI.Module("clikt") {
                             useConsole = instance()
                     ),
                     RankingSortStepsAppendCommand(
+                            di = di,
+                            useConsole = instance()
+                    ),
+                    RankingSortListCommand(
                             di = di,
                             useConsole = instance()
                     )

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/di/CliktModule.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/di/CliktModule.kt
@@ -96,6 +96,10 @@ val cliktModule = DI.Module("clikt") {
                     RankingSortGetCommand(
                             di = di,
                             useConsole = instance()
+                    ),
+                    RankingSortSetCommand(
+                            di = di,
+                            useConsole = instance()
                     )
             )
     }

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/di/CliktModule.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/di/CliktModule.kt
@@ -7,6 +7,8 @@ import com.github.ajalt.clikt.output.defaultCliktConsole
 import org.coner.trailer.cli.command.*
 import org.coner.trailer.cli.command.config.*
 import org.coner.trailer.cli.command.participanteventresultpointscalculator.*
+import org.coner.trailer.cli.command.rankingsort.RankingSortAddCommand
+import org.coner.trailer.cli.command.rankingsort.RankingSortCommand
 import org.kodein.di.DI
 import org.kodein.di.bind
 import org.kodein.di.instance
@@ -19,7 +21,8 @@ val cliktModule = DI.Module("clikt") {
     )
             .subcommands(
                     instance<ConfigCommand>(),
-                    instance<ParticipantEventResultPointsCalculatorCommand>()
+                    instance<ParticipantEventResultPointsCalculatorCommand>(),
+                    instance<RankingSortCommand>()
             )
     }
     bind<ConfigCommand>() with singleton { ConfigCommand()
@@ -72,6 +75,14 @@ val cliktModule = DI.Module("clikt") {
                             useConsole = instance()
                     ),
                     ParticipantEventResultPointsCalculatorDeleteCommand(
+                            di = di,
+                            useConsole = instance()
+                    )
+            )
+    }
+    bind<RankingSortCommand>() with singleton { RankingSortCommand()
+            .subcommands(
+                    RankingSortAddCommand(
                             di = di,
                             useConsole = instance()
                     )

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/di/DatabaseServiceModule.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/di/DatabaseServiceModule.kt
@@ -6,6 +6,8 @@ import org.coner.trailer.datasource.snoozle.ConerTrailerDatabase
 import org.coner.trailer.datasource.snoozle.ParticipantEventResultPointsCalculatorResource
 import org.coner.trailer.datasource.snoozle.RankingSortResource
 import org.coner.trailer.datasource.snoozle.entity.ParticipantEventResultPointsCalculatorEntity
+import org.coner.trailer.io.constraint.ParticipantEventResultPointsCalculatorPersistConstraints
+import org.coner.trailer.io.constraint.RankingSortPersistConstraints
 import org.coner.trailer.io.mapper.ParticipantEventResultPointsCalculatorMapper
 import org.coner.trailer.io.mapper.RankingSortMapper
 import org.coner.trailer.io.service.RankingSortService
@@ -22,19 +24,39 @@ fun databaseServiceModule(databaseConfiguration: DatabaseConfiguration) = DI.Mod
     bind<ParticipantEventResultPointsCalculatorResource>() with singleton {
         instance<ConerTrailerDatabase>().entity()
     }
+    bind<ParticipantEventResultPointsCalculatorMapper>() with singleton {
+        ParticipantEventResultPointsCalculatorMapper()
+    }
+    bind<ParticipantEventResultPointsCalculatorPersistConstraints>() with singleton {
+        ParticipantEventResultPointsCalculatorPersistConstraints(
+                resource = instance(),
+                mapper = instance()
+        )
+    }
     bind<ParticipantEventResultPointsCalculatorService>() with singleton {
         ParticipantEventResultPointsCalculatorService(
                 resource = instance(),
-                mapper = ParticipantEventResultPointsCalculatorMapper()
+                mapper = instance(),
+                persistConstraints = instance()
         )
     }
     bind<RankingSortResource>() with singleton {
         instance<ConerTrailerDatabase>().entity()
     }
+    bind<RankingSortMapper>() with singleton {
+        RankingSortMapper()
+    }
+    bind<RankingSortPersistConstraints>() with singleton {
+        RankingSortPersistConstraints(
+                resource = instance(),
+                mapper = instance()
+        )
+    }
     bind<RankingSortService>() with singleton {
         RankingSortService(
                 resource = instance(),
-                mapper = RankingSortMapper()
+                mapper = instance(),
+                persistConstraints = instance()
         )
     }
 }

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/di/DatabaseServiceModule.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/di/DatabaseServiceModule.kt
@@ -4,8 +4,11 @@ import org.coner.trailer.cli.io.DatabaseConfiguration
 import org.coner.trailer.io.service.ParticipantEventResultPointsCalculatorService
 import org.coner.trailer.datasource.snoozle.ConerTrailerDatabase
 import org.coner.trailer.datasource.snoozle.ParticipantEventResultPointsCalculatorResource
+import org.coner.trailer.datasource.snoozle.RankingSortResource
 import org.coner.trailer.datasource.snoozle.entity.ParticipantEventResultPointsCalculatorEntity
 import org.coner.trailer.io.mapper.ParticipantEventResultPointsCalculatorMapper
+import org.coner.trailer.io.mapper.RankingSortMapper
+import org.coner.trailer.io.service.RankingSortService
 import org.kodein.di.DI
 import org.kodein.di.bind
 import org.kodein.di.instance
@@ -17,12 +20,21 @@ fun databaseServiceModule(databaseConfiguration: DatabaseConfiguration) = DI.Mod
             root = databaseConfiguration.snoozleDatabase.toPath())
     }
     bind<ParticipantEventResultPointsCalculatorResource>() with singleton {
-        instance<ConerTrailerDatabase>().entity<ParticipantEventResultPointsCalculatorEntity.Key, ParticipantEventResultPointsCalculatorEntity>()
+        instance<ConerTrailerDatabase>().entity()
     }
     bind<ParticipantEventResultPointsCalculatorService>() with singleton {
         ParticipantEventResultPointsCalculatorService(
                 resource = instance(),
                 mapper = ParticipantEventResultPointsCalculatorMapper()
+        )
+    }
+    bind<RankingSortResource>() with singleton {
+        instance<ConerTrailerDatabase>().entity()
+    }
+    bind<RankingSortService>() with singleton {
+        RankingSortService(
+                resource = instance(),
+                mapper = RankingSortMapper()
         )
     }
 }

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/di/ViewModule.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/di/ViewModule.kt
@@ -2,6 +2,7 @@ package org.coner.trailer.cli.di
 
 import org.coner.trailer.cli.view.DatabaseConfigurationView
 import org.coner.trailer.cli.view.ParticipantEventResultPointsCalculatorView
+import org.coner.trailer.cli.view.RankingSortView
 import org.kodein.di.DI
 import org.kodein.di.bind
 import org.kodein.di.instance
@@ -12,6 +13,9 @@ val viewModule = DI.Module("view") {
             console = instance()
     ) }
     bind<ParticipantEventResultPointsCalculatorView>() with provider { ParticipantEventResultPointsCalculatorView(
+            console = instance()
+    ) }
+    bind<RankingSortView>() with provider { RankingSortView(
             console = instance()
     ) }
 }

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/view/RankingSortView.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/view/RankingSortView.kt
@@ -7,17 +7,19 @@ class RankingSortView(override val console: CliktConsole) : CollectionView<Ranki
     override fun render(model: RankingSort) = """
         ${model.name}
             ID:     ${model.id}
-            Steps:  
-                    ${render(model.steps)}
+            Steps:
+        ${render(model.steps)}
     """.trimIndent()
 
     private fun render(steps: List<RankingSort.Step>): String {
         return steps.map {
             when (it) {
-                RankingSort.Step.ScoreDescending -> "Score Descending"
+                is RankingSort.Step.ScoreDescending -> "Score Descending"
                 is RankingSort.Step.PositionFinishCountDescending -> "Position (${it.position}) Finish Count"
-                RankingSort.Step.AverageMarginOfVictoryDescending -> "Average Margin of Victory Descending"
+                is RankingSort.Step.AverageMarginOfVictoryDescending -> "Average Margin of Victory Descending"
             }
-        }.joinToString(separator = console.lineSeparator) { it.prependIndent(" ".repeat(8)) }
+        }.joinToString(separator = console.lineSeparator) {
+            "- $it".prependIndent(" ".repeat(12))
+        }
     }
 }

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/view/RankingSortView.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/view/RankingSortView.kt
@@ -1,0 +1,23 @@
+package org.coner.trailer.cli.view
+
+import com.github.ajalt.clikt.output.CliktConsole
+import org.coner.trailer.seasonpoints.RankingSort
+
+class RankingSortView(override val console: CliktConsole) : CollectionView<RankingSort> {
+    override fun render(model: RankingSort) = """
+        ${model.name}
+            ID:     ${model.id}
+            Steps:  
+                    ${render(model.steps)}
+    """.trimIndent()
+
+    private fun render(steps: List<RankingSort.Step>): String {
+        return steps.map {
+            when (it) {
+                RankingSort.Step.ScoreDescending -> "Score Descending"
+                is RankingSort.Step.PositionFinishCountDescending -> "Position (${it.position}) Finish Count"
+                RankingSort.Step.AverageMarginOfVictoryDescending -> "Average Margin of Victory Descending"
+            }
+        }.joinToString(separator = console.lineSeparator) { it.prependIndent(" ".repeat(8)) }
+    }
+}

--- a/modules/cli/src/main/kotlin/org/coner/trailer/cli/view/RankingSortView.kt
+++ b/modules/cli/src/main/kotlin/org/coner/trailer/cli/view/RankingSortView.kt
@@ -5,17 +5,17 @@ import org.coner.trailer.seasonpoints.RankingSort
 
 class RankingSortView(override val console: CliktConsole) : CollectionView<RankingSort> {
     override fun render(model: RankingSort) = """
-        ${model.name}
-            ID:     ${model.id}
-            Steps:
-        ${render(model.steps)}
-    """.trimIndent()
+        |${model.name}
+        |    ID:     ${model.id}
+        |    Steps:
+        |${render(model.steps)}
+    """.trimMargin()
 
     private fun render(steps: List<RankingSort.Step>): String {
         return steps.map {
             when (it) {
                 is RankingSort.Step.ScoreDescending -> "Score Descending"
-                is RankingSort.Step.PositionFinishCountDescending -> "Position (${it.position}) Finish Count"
+                is RankingSort.Step.PositionFinishCountDescending -> "Position Finish Count Descending: ${it.position}"
                 is RankingSort.Step.AverageMarginOfVictoryDescending -> "Average Margin of Victory Descending"
             }
         }.joinToString(separator = console.lineSeparator) {

--- a/modules/cli/src/test/kotlin/org/coner/trailer/cli/command/RootCommandTest.kt
+++ b/modules/cli/src/test/kotlin/org/coner/trailer/cli/command/RootCommandTest.kt
@@ -12,6 +12,7 @@ import io.mockk.every
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.verify
 import org.coner.trailer.cli.clikt.StringBufferConsole
+import org.coner.trailer.cli.command.config.ConfigCommand
 import org.coner.trailer.cli.io.ConfigurationService
 import org.coner.trailer.cli.io.DatabaseConfiguration
 import org.coner.trailer.cli.io.TestDatabaseConfigurations

--- a/modules/cli/src/test/kotlin/org/coner/trailer/cli/command/config/ConfigDatabaseGetCommandTest.kt
+++ b/modules/cli/src/test/kotlin/org/coner/trailer/cli/command/config/ConfigDatabaseGetCommandTest.kt
@@ -1,10 +1,9 @@
-package org.coner.trailer.cli.command
+package org.coner.trailer.cli.command.config
 
 import assertk.assertThat
 import com.github.ajalt.clikt.core.BadParameterValue
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
-import io.mockk.impl.annotations.RelaxedMockK
 import org.coner.trailer.cli.clikt.StringBufferConsole
 import org.coner.trailer.cli.io.ConfigurationService
 import org.coner.trailer.cli.io.TestDatabaseConfigurations

--- a/modules/cli/src/test/kotlin/org/coner/trailer/cli/command/config/ConfigDatabaseListCommandTest.kt
+++ b/modules/cli/src/test/kotlin/org/coner/trailer/cli/command/config/ConfigDatabaseListCommandTest.kt
@@ -1,6 +1,5 @@
-package org.coner.trailer.cli.command
+package org.coner.trailer.cli.command.config
 
-import assertk.all
 import assertk.assertThat
 import assertk.assertions.*
 import io.mockk.*

--- a/modules/cli/src/test/kotlin/org/coner/trailer/cli/command/config/ConfigDatabaseRemoveCommandTest.kt
+++ b/modules/cli/src/test/kotlin/org/coner/trailer/cli/command/config/ConfigDatabaseRemoveCommandTest.kt
@@ -1,4 +1,4 @@
-package org.coner.trailer.cli.command
+package org.coner.trailer.cli.command.config
 
 import com.github.ajalt.clikt.core.Abort
 import com.github.ajalt.clikt.core.BadParameterValue
@@ -6,7 +6,6 @@ import com.github.ajalt.clikt.core.PrintHelpMessage
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
 import org.coner.trailer.cli.io.ConfigurationService
-import org.coner.trailer.cli.io.DatabaseConfiguration
 import org.coner.trailer.cli.io.TestDatabaseConfigurations
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/modules/cli/src/test/kotlin/org/coner/trailer/cli/command/config/ConfigDatabaseSetCommandTest.kt
+++ b/modules/cli/src/test/kotlin/org/coner/trailer/cli/command/config/ConfigDatabaseSetCommandTest.kt
@@ -1,4 +1,4 @@
-package org.coner.trailer.cli.command
+package org.coner.trailer.cli.command.config
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
@@ -8,6 +8,7 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.slot
 import io.mockk.verifySequence
 import org.coner.trailer.cli.clikt.StringBufferConsole
+import org.coner.trailer.cli.command.config.ConfigDatabaseSetCommand
 import org.coner.trailer.cli.io.ConfigurationService
 import org.coner.trailer.cli.io.DatabaseConfiguration
 import org.coner.trailer.cli.io.TestDatabaseConfigurations

--- a/modules/cli/src/test/kotlin/org/coner/trailer/cli/command/config/ConfigDatabaseSetDefaultCommandTest.kt
+++ b/modules/cli/src/test/kotlin/org/coner/trailer/cli/command/config/ConfigDatabaseSetDefaultCommandTest.kt
@@ -1,12 +1,10 @@
-package org.coner.trailer.cli.command
+package org.coner.trailer.cli.command.config
 
 import assertk.all
 import assertk.assertThat
 import assertk.assertions.isEqualToIgnoringGivenProperties
-import assertk.assertions.isNotNull
 import assertk.assertions.isTrue
 import assertk.assertions.prop
-import com.github.ajalt.clikt.core.Abort
 import com.github.ajalt.clikt.core.BadParameterValue
 import io.mockk.*
 import io.mockk.impl.annotations.MockK

--- a/modules/cli/src/test/kotlin/org/coner/trailer/cli/command/participanteventresultpointscalculator/ParticipantEventResultPointsCalculatorAddCommandTest.kt
+++ b/modules/cli/src/test/kotlin/org/coner/trailer/cli/command/participanteventresultpointscalculator/ParticipantEventResultPointsCalculatorAddCommandTest.kt
@@ -1,4 +1,4 @@
-package org.coner.trailer.cli.command
+package org.coner.trailer.cli.command.participanteventresultpointscalculator
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
@@ -16,9 +16,9 @@ import org.kodein.di.DI
 import org.kodein.di.bind
 import org.kodein.di.instance
 
-class ParticipantEventResultPointsCalculatorGetCommandTest {
+class ParticipantEventResultPointsCalculatorAddCommandTest {
 
-    lateinit var command: ParticipantEventResultPointsCalculatorGetCommand
+    lateinit var command: ParticipantEventResultPointsCalculatorAddCommand
 
     @MockK
     lateinit var service: ParticipantEventResultPointsCalculatorService
@@ -35,44 +35,40 @@ class ParticipantEventResultPointsCalculatorGetCommandTest {
     }
 
     @Test
-    fun `It should get calculator by id`() {
+    fun `It should create calculator`() {
         val calculator = TestParticipantEventResultPointsCalculators.lsccGroupingCalculator
-        every { service.findById(calculator.id) } returns calculator
-        val viewRenders = "rendered ${calculator.name}"
-        every { view.render(calculator) } returns viewRenders
+        every { service.hasNewName(calculator.name) } returns true
+        every { service.create(eq(calculator)) } answers { Unit }
+        val viewRenders = "created ${calculator.id}"
+        every { view.render(eq(calculator)) } returns viewRenders
 
-        command.parse(arrayOf("--id", calculator.id.toString()))
+        command.parse(arrayOf(
+                "--id", calculator.id.toString(),
+                "--name", calculator.name,
+                "--position-to-points", "1", "9",
+                "--position-to-points", "2", "6",
+                "--position-to-points", "3", "4",
+                "--position-to-points", "4", "3",
+                "--position-to-points", "5", "2",
+                "--default-points", "1"
+        ))
 
-        assertThat(console.output).isEqualTo(viewRenders)
         verifySequence {
-            service.findById(calculator.id)
-            view.render(calculator)
+            service.hasNewName(calculator.name)
+            service.create(eq(calculator))
+            view.render(eq(calculator))
         }
-    }
-
-    @Test
-    fun `It should get calculator by name`() {
-        val calculator = TestParticipantEventResultPointsCalculators.lsccGroupingCalculator
-        every { service.findByName(calculator.name) } returns calculator
-        val viewRenders = "rendered ${calculator.id}"
-        every { view.render(calculator) } returns viewRenders
-
-        command.parse(arrayOf("--name", calculator.name))
-
         assertThat(console.output).isEqualTo(viewRenders)
-        verifySequence {
-            service.findByName(calculator.name)
-            view.render(calculator)
-        }
     }
 }
 
-private fun ParticipantEventResultPointsCalculatorGetCommandTest.arrangeCommand() {
+
+private fun ParticipantEventResultPointsCalculatorAddCommandTest.arrangeCommand() {
     val di = DI {
         bind<ParticipantEventResultPointsCalculatorService>() with instance(service)
         bind<ParticipantEventResultPointsCalculatorView>() with instance(view)
     }
-    command = ParticipantEventResultPointsCalculatorGetCommand(
+    command = ParticipantEventResultPointsCalculatorAddCommand(
             di = di,
             useConsole = console
     )

--- a/modules/cli/src/test/kotlin/org/coner/trailer/cli/command/participanteventresultpointscalculator/ParticipantEventResultPointsCalculatorAddCommandTest.kt
+++ b/modules/cli/src/test/kotlin/org/coner/trailer/cli/command/participanteventresultpointscalculator/ParticipantEventResultPointsCalculatorAddCommandTest.kt
@@ -37,7 +37,6 @@ class ParticipantEventResultPointsCalculatorAddCommandTest {
     @Test
     fun `It should create calculator`() {
         val calculator = TestParticipantEventResultPointsCalculators.lsccGroupingCalculator
-        every { service.hasNewName(calculator.name) } returns true
         every { service.create(eq(calculator)) } answers { Unit }
         val viewRenders = "created ${calculator.id}"
         every { view.render(eq(calculator)) } returns viewRenders
@@ -54,7 +53,6 @@ class ParticipantEventResultPointsCalculatorAddCommandTest {
         ))
 
         verifySequence {
-            service.hasNewName(calculator.name)
             service.create(eq(calculator))
             view.render(eq(calculator))
         }

--- a/modules/cli/src/test/kotlin/org/coner/trailer/cli/command/participanteventresultpointscalculator/ParticipantEventResultPointsCalculatorAddCommandTest.kt
+++ b/modules/cli/src/test/kotlin/org/coner/trailer/cli/command/participanteventresultpointscalculator/ParticipantEventResultPointsCalculatorAddCommandTest.kt
@@ -9,6 +9,7 @@ import io.mockk.verifySequence
 import org.coner.trailer.TestParticipantEventResultPointsCalculators
 import org.coner.trailer.cli.clikt.StringBufferConsole
 import org.coner.trailer.cli.view.ParticipantEventResultPointsCalculatorView
+import org.coner.trailer.io.constraint.ParticipantEventResultPointsCalculatorPersistConstraints
 import org.coner.trailer.io.service.ParticipantEventResultPointsCalculatorService
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -20,6 +21,8 @@ class ParticipantEventResultPointsCalculatorAddCommandTest {
 
     lateinit var command: ParticipantEventResultPointsCalculatorAddCommand
 
+    @MockK
+    lateinit var constraints: ParticipantEventResultPointsCalculatorPersistConstraints
     @MockK
     lateinit var service: ParticipantEventResultPointsCalculatorService
     @MockK
@@ -37,6 +40,7 @@ class ParticipantEventResultPointsCalculatorAddCommandTest {
     @Test
     fun `It should create calculator`() {
         val calculator = TestParticipantEventResultPointsCalculators.lsccGroupingCalculator
+        every { constraints.hasUniqueName(calculator.id, calculator.name) } returns true
         every { service.create(eq(calculator)) } answers { Unit }
         val viewRenders = "created ${calculator.id}"
         every { view.render(eq(calculator)) } returns viewRenders
@@ -63,6 +67,7 @@ class ParticipantEventResultPointsCalculatorAddCommandTest {
 
 private fun ParticipantEventResultPointsCalculatorAddCommandTest.arrangeCommand() {
     val di = DI {
+        bind<ParticipantEventResultPointsCalculatorPersistConstraints>() with instance(constraints)
         bind<ParticipantEventResultPointsCalculatorService>() with instance(service)
         bind<ParticipantEventResultPointsCalculatorView>() with instance(view)
     }

--- a/modules/cli/src/test/kotlin/org/coner/trailer/cli/command/participanteventresultpointscalculator/ParticipantEventResultPointsCalculatorDeleteCommandTest.kt
+++ b/modules/cli/src/test/kotlin/org/coner/trailer/cli/command/participanteventresultpointscalculator/ParticipantEventResultPointsCalculatorDeleteCommandTest.kt
@@ -1,4 +1,4 @@
-package org.coner.trailer.cli.command
+package org.coner.trailer.cli.command.participanteventresultpointscalculator
 
 import io.mockk.MockKAnnotations
 import io.mockk.every

--- a/modules/cli/src/test/kotlin/org/coner/trailer/cli/command/participanteventresultpointscalculator/ParticipantEventResultPointsCalculatorGetCommandTest.kt
+++ b/modules/cli/src/test/kotlin/org/coner/trailer/cli/command/participanteventresultpointscalculator/ParticipantEventResultPointsCalculatorGetCommandTest.kt
@@ -1,4 +1,4 @@
-package org.coner.trailer.cli.command
+package org.coner.trailer.cli.command.participanteventresultpointscalculator
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
@@ -16,9 +16,9 @@ import org.kodein.di.DI
 import org.kodein.di.bind
 import org.kodein.di.instance
 
-class ParticipantEventResultPointsCalculatorAddCommandTest {
+class ParticipantEventResultPointsCalculatorGetCommandTest {
 
-    lateinit var command: ParticipantEventResultPointsCalculatorAddCommand
+    lateinit var command: ParticipantEventResultPointsCalculatorGetCommand
 
     @MockK
     lateinit var service: ParticipantEventResultPointsCalculatorService
@@ -35,40 +35,44 @@ class ParticipantEventResultPointsCalculatorAddCommandTest {
     }
 
     @Test
-    fun `It should create calculator`() {
+    fun `It should get calculator by id`() {
         val calculator = TestParticipantEventResultPointsCalculators.lsccGroupingCalculator
-        every { service.hasNewName(calculator.name) } returns true
-        every { service.create(eq(calculator)) } answers { Unit }
-        val viewRenders = "created ${calculator.id}"
-        every { view.render(eq(calculator)) } returns viewRenders
+        every { service.findById(calculator.id) } returns calculator
+        val viewRenders = "rendered ${calculator.name}"
+        every { view.render(calculator) } returns viewRenders
 
-        command.parse(arrayOf(
-                "--id", calculator.id.toString(),
-                "--name", calculator.name,
-                "--position-to-points", "1", "9",
-                "--position-to-points", "2", "6",
-                "--position-to-points", "3", "4",
-                "--position-to-points", "4", "3",
-                "--position-to-points", "5", "2",
-                "--default-points", "1"
-        ))
+        command.parse(arrayOf("--id", calculator.id.toString()))
 
-        verifySequence {
-            service.hasNewName(calculator.name)
-            service.create(eq(calculator))
-            view.render(eq(calculator))
-        }
         assertThat(console.output).isEqualTo(viewRenders)
+        verifySequence {
+            service.findById(calculator.id)
+            view.render(calculator)
+        }
+    }
+
+    @Test
+    fun `It should get calculator by name`() {
+        val calculator = TestParticipantEventResultPointsCalculators.lsccGroupingCalculator
+        every { service.findByName(calculator.name) } returns calculator
+        val viewRenders = "rendered ${calculator.id}"
+        every { view.render(calculator) } returns viewRenders
+
+        command.parse(arrayOf("--name", calculator.name))
+
+        assertThat(console.output).isEqualTo(viewRenders)
+        verifySequence {
+            service.findByName(calculator.name)
+            view.render(calculator)
+        }
     }
 }
 
-
-private fun ParticipantEventResultPointsCalculatorAddCommandTest.arrangeCommand() {
+private fun ParticipantEventResultPointsCalculatorGetCommandTest.arrangeCommand() {
     val di = DI {
         bind<ParticipantEventResultPointsCalculatorService>() with instance(service)
         bind<ParticipantEventResultPointsCalculatorView>() with instance(view)
     }
-    command = ParticipantEventResultPointsCalculatorAddCommand(
+    command = ParticipantEventResultPointsCalculatorGetCommand(
             di = di,
             useConsole = console
     )

--- a/modules/cli/src/test/kotlin/org/coner/trailer/cli/command/participanteventresultpointscalculator/ParticipantEventResultPointsCalculatorSetCommandTest.kt
+++ b/modules/cli/src/test/kotlin/org/coner/trailer/cli/command/participanteventresultpointscalculator/ParticipantEventResultPointsCalculatorSetCommandTest.kt
@@ -1,4 +1,4 @@
-package org.coner.trailer.cli.command
+package org.coner.trailer.cli.command.participanteventresultpointscalculator
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo

--- a/modules/cli/src/test/kotlin/org/coner/trailer/cli/command/participanteventresultpointscalculator/ParticipantEventResultPointsCalculatorSetCommandTest.kt
+++ b/modules/cli/src/test/kotlin/org/coner/trailer/cli/command/participanteventresultpointscalculator/ParticipantEventResultPointsCalculatorSetCommandTest.kt
@@ -49,7 +49,6 @@ class ParticipantEventResultPointsCalculatorSetCommandTest {
                 ),
                 defaultPoints = 2
         )
-        every { service.hasNewName(set.name) } returns true
         every { service.update(eq(set)) } answers { Unit }
         val viewRendered = "view rendered ${set.name}"
         every { view.render(eq(set)) } returns viewRendered
@@ -66,7 +65,6 @@ class ParticipantEventResultPointsCalculatorSetCommandTest {
         ))
 
         verifySequence {
-            service.hasNewName(set.name)
             service.findById(set.id)
             service.update(eq(set))
             view.render(eq(set))
@@ -81,7 +79,6 @@ class ParticipantEventResultPointsCalculatorSetCommandTest {
         val set = calculator.copy(
                 name = "set"
         )
-        every { service.hasNewName(set.name) } returns true
         every { service.update(eq(set)) } answers { Unit }
         val viewRendered = "view rendered ${set.name}"
         every { view.render(eq(set)) } returns viewRendered
@@ -92,7 +89,6 @@ class ParticipantEventResultPointsCalculatorSetCommandTest {
         ))
 
         verifySequence {
-            service.hasNewName(set.name)
             service.findById(set.id)
             service.update(eq(set))
             view.render(eq(set))

--- a/modules/cli/src/test/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortAddCommandTest.kt
+++ b/modules/cli/src/test/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortAddCommandTest.kt
@@ -1,0 +1,79 @@
+package org.coner.trailer.cli.command.rankingsort
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.verifySequence
+import org.coner.trailer.cli.clikt.StringBufferConsole
+import org.coner.trailer.cli.view.RankingSortView
+import org.coner.trailer.io.constraint.RankingSortPersistConstraints
+import org.coner.trailer.io.service.RankingSortService
+import org.coner.trailer.seasonpoints.RankingSort
+import org.coner.trailer.seasonpoints.TestRankingSorts
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.kodein.di.DI
+import org.kodein.di.bind
+import org.kodein.di.instance
+
+class RankingSortAddCommandTest {
+
+    lateinit var command: RankingSortAddCommand
+
+    @MockK
+    lateinit var constraints: RankingSortPersistConstraints
+    @MockK
+    lateinit var service: RankingSortService
+    @MockK
+    lateinit var view: RankingSortView
+
+    lateinit var console: StringBufferConsole
+
+    @BeforeEach
+    fun before() {
+        MockKAnnotations.init(this)
+        console = StringBufferConsole()
+        arrangeCommand()
+    }
+
+    @Test
+    fun `It should add a ranking sort`() {
+        val lsccRankingSort = TestRankingSorts.lscc
+        val rankingSort = RankingSort(
+                id = lsccRankingSort.id,
+                name = lsccRankingSort.name,
+                steps = listOf(RankingSort.Step.ScoreDescending())
+        )
+        every { constraints.hasUniqueName(rankingSort.id, rankingSort.name) } returns true
+        every { service.create(eq(rankingSort)) } answers { Unit }
+        val viewRendered = "view rendered ${rankingSort.name}"
+        every { view.render(rankingSort) } returns viewRendered
+
+        command.parse(arrayOf(
+                "--id", rankingSort.id.toString(),
+                "--name", rankingSort.name,
+                "--score-descending"
+        ))
+
+        verifySequence {
+            constraints.hasUniqueName(rankingSort.id, rankingSort.name)
+            service.create(eq(rankingSort))
+            view.render(eq(rankingSort))
+        }
+        assertThat(console.output).isEqualTo(viewRendered)
+    }
+}
+
+private fun RankingSortAddCommandTest.arrangeCommand() {
+    val di = DI {
+        bind<RankingSortPersistConstraints>() with instance(constraints)
+        bind<RankingSortService>() with instance(service)
+        bind<RankingSortView>() with instance(view)
+    }
+    command = RankingSortAddCommand(
+            useConsole = console,
+            di = di
+    )
+}

--- a/modules/cli/src/test/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortStepsAppendCommandTest.kt
+++ b/modules/cli/src/test/kotlin/org/coner/trailer/cli/command/rankingsort/RankingSortStepsAppendCommandTest.kt
@@ -1,0 +1,78 @@
+package org.coner.trailer.cli.command.rankingsort
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.verifySequence
+import org.coner.trailer.cli.clikt.StringBufferConsole
+import org.coner.trailer.cli.view.RankingSortView
+import org.coner.trailer.io.service.RankingSortService
+import org.coner.trailer.seasonpoints.RankingSort
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.kodein.di.DI
+import org.kodein.di.bind
+import org.kodein.di.instance
+
+class RankingSortStepsAppendCommandTest {
+
+    lateinit var command: RankingSortStepsAppendCommand
+
+    @MockK
+    lateinit var service: RankingSortService
+    @MockK
+    lateinit var view: RankingSortView
+
+    lateinit var console: StringBufferConsole
+
+    @BeforeEach
+    fun before() {
+        MockKAnnotations.init(this)
+        console = StringBufferConsole()
+        arrangeCommand()
+    }
+
+    @Test
+    fun `It should append step`() {
+        val before = RankingSort(
+                name = "ranking sort",
+                steps = listOf(RankingSort.Step.ScoreDescending())
+        )
+        val append = RankingSort.Step.PositionFinishCountDescending(1)
+        val expected = before.copy(
+                steps = listOf(
+                        RankingSort.Step.ScoreDescending(),
+                        append
+                )
+        )
+        every { service.findById(before.id) } returns before
+        every { service.update(eq(expected)) } answers { Unit }
+        val viewRendered = "view rendered ${expected.name}"
+        every { view.render(eq(expected)) } returns viewRendered
+
+        command.parse(arrayOf(
+                before.id.toString(),
+                "--position-finish-count-descending", "--position", "1"
+        ))
+
+        verifySequence {
+            service.findById(before.id)
+            service.update(eq(expected))
+            view.render(eq(expected))
+        }
+        assertThat(console.output).isEqualTo(viewRendered)
+    }
+}
+
+private fun RankingSortStepsAppendCommandTest.arrangeCommand() {
+    val di = DI {
+        bind<RankingSortService>() with instance(service)
+        bind<RankingSortView>() with instance(view)
+    }
+    command = RankingSortStepsAppendCommand(
+            di = di,
+            useConsole = console
+    )
+}

--- a/modules/core-test/src/main/kotlin/org/coner/trailer/seasonpoints/TestRankingSorts.kt
+++ b/modules/core-test/src/main/kotlin/org/coner/trailer/seasonpoints/TestRankingSorts.kt
@@ -3,6 +3,7 @@ package org.coner.trailer.seasonpoints
 object TestRankingSorts {
 
     val lscc = RankingSort(
+            name = "LSCC",
             steps = listOf(
                     RankingSort.Step.ScoreDescending,
                     RankingSort.Step.PositionFinishCountDescending(1),
@@ -12,6 +13,7 @@ object TestRankingSorts {
     )
 
     val olscc = RankingSort(
+            name = "OLSCC",
             steps = listOf(
                     RankingSort.Step.ScoreDescending,
                     RankingSort.Step.AverageMarginOfVictoryDescending

--- a/modules/core-test/src/main/kotlin/org/coner/trailer/seasonpoints/TestRankingSorts.kt
+++ b/modules/core-test/src/main/kotlin/org/coner/trailer/seasonpoints/TestRankingSorts.kt
@@ -5,7 +5,7 @@ object TestRankingSorts {
     val lscc = RankingSort(
             name = "LSCC",
             steps = listOf(
-                    RankingSort.Step.ScoreDescending,
+                    RankingSort.Step.ScoreDescending(0),
                     RankingSort.Step.PositionFinishCountDescending(1),
                     RankingSort.Step.PositionFinishCountDescending(2),
                     RankingSort.Step.PositionFinishCountDescending(3)
@@ -15,8 +15,8 @@ object TestRankingSorts {
     val olscc = RankingSort(
             name = "OLSCC",
             steps = listOf(
-                    RankingSort.Step.ScoreDescending,
-                    RankingSort.Step.AverageMarginOfVictoryDescending
+                    RankingSort.Step.ScoreDescending(0),
+                    RankingSort.Step.AverageMarginOfVictoryDescending(1)
             )
     )
 }

--- a/modules/core-test/src/main/kotlin/org/coner/trailer/seasonpoints/TestRankingSorts.kt
+++ b/modules/core-test/src/main/kotlin/org/coner/trailer/seasonpoints/TestRankingSorts.kt
@@ -1,13 +1,20 @@
 package org.coner.trailer.seasonpoints
 
 object TestRankingSorts {
-    val lscc: Comparator<PersonStandingAccumulator>
-        get() = compareByDescending<PersonStandingAccumulator> { it.score }
-                .thenByPositionFinishCountDescending(1)
-                .thenByPositionFinishCountDescending(2)
-                .thenByPositionFinishCountDescending(3)
 
-    val olscc: Comparator<PersonStandingAccumulator>
-        get() = compareByDescending<PersonStandingAccumulator> { it.score }
-                .thenByAverageMarginOfVictoryDescending()
+    val lscc = RankingSort(
+            steps = listOf(
+                    RankingSort.Step.ScoreDescending,
+                    RankingSort.Step.PositionFinishCountDescending(1),
+                    RankingSort.Step.PositionFinishCountDescending(2),
+                    RankingSort.Step.PositionFinishCountDescending(3)
+            )
+    )
+
+    val olscc = RankingSort(
+            steps = listOf(
+                    RankingSort.Step.ScoreDescending,
+                    RankingSort.Step.AverageMarginOfVictoryDescending
+            )
+    )
 }

--- a/modules/core/src/main/kotlin/org/coner/trailer/seasonpoints/PersonStandingAccumulator.kt
+++ b/modules/core/src/main/kotlin/org/coner/trailer/seasonpoints/PersonStandingAccumulator.kt
@@ -16,10 +16,6 @@ class PersonStandingAccumulator(
     var tie: Boolean = false
 }
 
-fun Comparator<PersonStandingAccumulator>.thenByPositionFinishCountDescending(position: Int): Comparator<PersonStandingAccumulator> {
-    return thenByDescending { it.positionToFinishCount[position] ?: 0 }
-}
-
 fun Comparator<PersonStandingAccumulator>.thenByAverageMarginOfVictoryDescending(): Comparator<PersonStandingAccumulator> {
     return thenByDescending { it.marginsOfVictory.average() }
 }

--- a/modules/core/src/main/kotlin/org/coner/trailer/seasonpoints/RankingSort.kt
+++ b/modules/core/src/main/kotlin/org/coner/trailer/seasonpoints/RankingSort.kt
@@ -6,7 +6,7 @@ import org.coner.trailer.eventresults.Score
 import java.util.*
 import kotlin.Comparator
 
-class RankingSort(
+data class RankingSort(
         val id: UUID = UUID.randomUUID(),
         val name: String,
         val steps: List<Step>
@@ -20,11 +20,11 @@ class RankingSort(
         var builder: Comparator<PersonStandingAccumulator>? = null
         steps.forEach { step ->
             builder = when (step) {
-                Step.ScoreDescending -> builder?.thenByDescending(step.comparable)
+                is Step.ScoreDescending -> builder?.thenByDescending(step.comparable)
                         ?: compareByDescending(step.comparable)
                 is Step.PositionFinishCountDescending -> builder?.thenByDescending(step.comparable)
                         ?: compareByDescending(step.comparable)
-                Step.AverageMarginOfVictoryDescending -> builder?.thenByDescending(step.comparable)
+                is Step.AverageMarginOfVictoryDescending -> builder?.thenByDescending(step.comparable)
                         ?: compareByDescending(step.comparable)
             }
         }
@@ -34,15 +34,17 @@ class RankingSort(
     sealed class Step {
         abstract val comparable: (PersonStandingAccumulator) -> Comparable<*>
 
-        object ScoreDescending : Step() {
+        data class ScoreDescending(val index: Int? = null) : Step() {
             override val comparable: (PersonStandingAccumulator) -> Comparable<*>
                 get() = { it.score }
+
         }
-        class PositionFinishCountDescending(val position: Int) : Step() {
+        data class PositionFinishCountDescending(val position: Int) : Step() {
             override val comparable: (PersonStandingAccumulator) -> Comparable<*>
                 get() = { it.positionToFinishCount[position] ?: 0 }
+
         }
-        object AverageMarginOfVictoryDescending : Step() {
+        data class AverageMarginOfVictoryDescending(val index: Int? = null) : Step() {
             override val comparable: (PersonStandingAccumulator) -> Comparable<*>
                 get() = { it.marginsOfVictory.average() ?: Time(Score.withoutTime().value) }
         }

--- a/modules/core/src/main/kotlin/org/coner/trailer/seasonpoints/RankingSort.kt
+++ b/modules/core/src/main/kotlin/org/coner/trailer/seasonpoints/RankingSort.kt
@@ -8,6 +8,7 @@ import kotlin.Comparator
 
 class RankingSort(
         val id: UUID = UUID.randomUUID(),
+        val name: String,
         val steps: List<Step>
 ) {
 

--- a/modules/core/src/main/kotlin/org/coner/trailer/seasonpoints/RankingSort.kt
+++ b/modules/core/src/main/kotlin/org/coner/trailer/seasonpoints/RankingSort.kt
@@ -1,0 +1,50 @@
+package org.coner.trailer.seasonpoints
+
+import org.coner.trailer.Time
+import org.coner.trailer.average
+import org.coner.trailer.eventresults.Score
+import java.util.*
+import kotlin.Comparator
+
+class RankingSort(
+        val id: UUID = UUID.randomUUID(),
+        val steps: List<Step>
+) {
+
+    init {
+        require(steps.isNotEmpty()) { "Steps required" }
+    }
+
+    val comparator: Comparator<PersonStandingAccumulator> by lazy {
+        var builder: Comparator<PersonStandingAccumulator>? = null
+        steps.forEach { step ->
+            builder = when (step) {
+                Step.ScoreDescending -> builder?.thenByDescending(step.comparable)
+                        ?: compareByDescending(step.comparable)
+                is Step.PositionFinishCountDescending -> builder?.thenByDescending(step.comparable)
+                        ?: compareByDescending(step.comparable)
+                Step.AverageMarginOfVictoryDescending -> builder?.thenByDescending(step.comparable)
+                        ?: compareByDescending(step.comparable)
+            }
+        }
+        checkNotNull(builder) { "model did not include sort steps" }
+    }
+
+    sealed class Step {
+        abstract val comparable: (PersonStandingAccumulator) -> Comparable<*>
+
+        object ScoreDescending : Step() {
+            override val comparable: (PersonStandingAccumulator) -> Comparable<*>
+                get() = { it.score }
+        }
+        class PositionFinishCountDescending(val position: Int) : Step() {
+            override val comparable: (PersonStandingAccumulator) -> Comparable<*>
+                get() = { it.positionToFinishCount[position] ?: 0 }
+        }
+        object AverageMarginOfVictoryDescending : Step() {
+            override val comparable: (PersonStandingAccumulator) -> Comparable<*>
+                get() = { it.marginsOfVictory.average() ?: Time(Score.withoutTime().value) }
+        }
+    }
+
+}

--- a/modules/core/src/main/kotlin/org/coner/trailer/seasonpoints/StandingsReportCreator.kt
+++ b/modules/core/src/main/kotlin/org/coner/trailer/seasonpoints/StandingsReportCreator.kt
@@ -22,7 +22,7 @@ class StandingsReportCreator {
             val season: Season,
             val eventToGroupedResultsReports: Map<SeasonEvent, GroupedResultsReport>,
             val takeTopEventScores: Int?,
-            val rankingSort: Comparator<PersonStandingAccumulator>
+            val rankingSort: RankingSort
     )
 
     fun createGroupedStandingsSections(param: CreateGroupedStandingsSectionsParameters): SortedMap<Grouping, StandingsReport.Section> {
@@ -74,14 +74,14 @@ class StandingsReportCreator {
         val groupingsToFinalAccumulators = groupingsToPersonStandingAccumulators.map { (grouping, peopleStandingAccumulators) ->
             val finalAccumulators = peopleStandingAccumulators.values
                     .toList()
-                    .sortedWith(param.rankingSort)
+                    .sortedWith(param.rankingSort.comparator)
             grouping to finalAccumulators
         }.toMap()
         groupingsToFinalAccumulators.forEach { (_, accumulators) ->
             accumulators.mapIndexed { index, accumulator ->
                 accumulator.position = if (index > 0) {
                     val previousAccumulator = accumulators[index - 1]
-                    val comparison = param.rankingSort.compare(accumulator, previousAccumulator)
+                    val comparison = param.rankingSort.comparator.compare(accumulator, previousAccumulator)
                     if (comparison != 0) {
                         checkNotNull(previousAccumulator.position) + 1
                     } else {

--- a/modules/datasource-snoozle/src/main/kotlin/org/coner/trailer/datasource/snoozle/ConerTrailerDatabase.kt
+++ b/modules/datasource-snoozle/src/main/kotlin/org/coner/trailer/datasource/snoozle/ConerTrailerDatabase.kt
@@ -3,6 +3,8 @@ package org.coner.trailer.datasource.snoozle
 import org.coner.snoozle.db.Database
 import org.coner.snoozle.db.entity.EntityResource
 import org.coner.trailer.datasource.snoozle.entity.ParticipantEventResultPointsCalculatorEntity
+import org.coner.trailer.datasource.snoozle.entity.RankingSortEntity
+import org.coner.trailer.seasonpoints.RankingSort
 import java.nio.file.Path
 
 class ConerTrailerDatabase(root: Path) : Database(root) {
@@ -13,7 +15,13 @@ class ConerTrailerDatabase(root: Path) : Database(root) {
             keyFromPath = { ParticipantEventResultPointsCalculatorEntity.Key(id = uuidAt(0)) }
             keyFromEntity = { ParticipantEventResultPointsCalculatorEntity.Key(id = id) }
         }
+        entity<RankingSortEntity.Key, RankingSortEntity> {
+            path = "rankingSorts" / { id } + ".json"
+            keyFromPath = { RankingSortEntity.Key(id = uuidAt(0)) }
+            keyFromEntity = { RankingSortEntity.Key(id = id) }
+        }
     }
 }
 
 typealias ParticipantEventResultPointsCalculatorResource = EntityResource<ParticipantEventResultPointsCalculatorEntity.Key, ParticipantEventResultPointsCalculatorEntity>
+typealias RankingSortResource = EntityResource<RankingSortEntity.Key, RankingSortEntity>

--- a/modules/datasource-snoozle/src/main/kotlin/org/coner/trailer/datasource/snoozle/entity/RankingSortEntity.kt
+++ b/modules/datasource-snoozle/src/main/kotlin/org/coner/trailer/datasource/snoozle/entity/RankingSortEntity.kt
@@ -1,0 +1,17 @@
+package org.coner.trailer.datasource.snoozle.entity
+
+import org.coner.snoozle.db.entity.Entity
+import java.util.*
+
+data class RankingSortEntity(
+        val id: UUID = UUID.randomUUID(),
+        val steps: List<Step>
+) : Entity<RankingSortEntity.Key> {
+
+    data class Step(
+            val type: String,
+            val p1: String? = null
+    )
+
+    data class Key(val id: UUID) : org.coner.snoozle.db.Key
+}

--- a/modules/datasource-snoozle/src/main/kotlin/org/coner/trailer/datasource/snoozle/entity/RankingSortEntity.kt
+++ b/modules/datasource-snoozle/src/main/kotlin/org/coner/trailer/datasource/snoozle/entity/RankingSortEntity.kt
@@ -5,12 +5,18 @@ import java.util.*
 
 data class RankingSortEntity(
         val id: UUID = UUID.randomUUID(),
-        val steps: List<Step>
+        val scoreDescendingSteps: List<IndexOnlyStep>,
+        val positionFinishCountDescendingSteps: List<PositionFinishCountDescendingStep>,
+        val averageMarginOfVictoryDescendingSteps: List<IndexOnlyStep>
 ) : Entity<RankingSortEntity.Key> {
 
-    data class Step(
-            val type: String,
-            val p1: String? = null
+    data class IndexOnlyStep(
+            val index: Int
+    )
+
+    data class PositionFinishCountDescendingStep(
+            val index: Int,
+            val position: Int
     )
 
     data class Key(val id: UUID) : org.coner.snoozle.db.Key

--- a/modules/datasource-snoozle/src/main/kotlin/org/coner/trailer/datasource/snoozle/entity/RankingSortEntity.kt
+++ b/modules/datasource-snoozle/src/main/kotlin/org/coner/trailer/datasource/snoozle/entity/RankingSortEntity.kt
@@ -5,19 +5,20 @@ import java.util.*
 
 data class RankingSortEntity(
         val id: UUID = UUID.randomUUID(),
-        val scoreDescendingSteps: List<IndexOnlyStep>,
-        val positionFinishCountDescendingSteps: List<PositionFinishCountDescendingStep>,
-        val averageMarginOfVictoryDescendingSteps: List<IndexOnlyStep>
+        val name: String,
+        val steps: List<Step>
 ) : Entity<RankingSortEntity.Key> {
 
-    data class IndexOnlyStep(
-            val index: Int
-    )
-
-    data class PositionFinishCountDescendingStep(
-            val index: Int,
-            val position: Int
-    )
+    data class Step(
+            val type: Type,
+            val paramInt1: Int? = null
+    ) {
+        enum class Type {
+            ScoreDescending,
+            PositionFinishCountDescending,
+            AverageMarginOfVictoryDescending
+        }
+    }
 
     data class Key(val id: UUID) : org.coner.snoozle.db.Key
 }

--- a/modules/io/src/main/kotlin/org/coner/trailer/io/constraint/Constraint.kt
+++ b/modules/io/src/main/kotlin/org/coner/trailer/io/constraint/Constraint.kt
@@ -1,0 +1,10 @@
+package org.coner.trailer.io.constraint
+
+abstract class Constraint<T> {
+
+    abstract fun assess(candidate: T)
+
+    protected inline fun constrain(satisfied: Boolean, message: () -> String) {
+        if (!satisfied) throw ConstraintViolationException(message())
+    }
+}

--- a/modules/io/src/main/kotlin/org/coner/trailer/io/constraint/ConstraintViolationException.kt
+++ b/modules/io/src/main/kotlin/org/coner/trailer/io/constraint/ConstraintViolationException.kt
@@ -1,0 +1,3 @@
+package org.coner.trailer.io.constraint
+
+class ConstraintViolationException(message: String?) : Throwable(message)

--- a/modules/io/src/main/kotlin/org/coner/trailer/io/constraint/ParticipantEventResultPointsCalculatorPersistConstraints.kt
+++ b/modules/io/src/main/kotlin/org/coner/trailer/io/constraint/ParticipantEventResultPointsCalculatorPersistConstraints.kt
@@ -1,0 +1,21 @@
+package org.coner.trailer.io.constraint
+
+import org.coner.trailer.datasource.snoozle.ParticipantEventResultPointsCalculatorResource
+import org.coner.trailer.io.mapper.ParticipantEventResultPointsCalculatorMapper
+import org.coner.trailer.seasonpoints.ParticipantEventResultPointsCalculator
+
+class ParticipantEventResultPointsCalculatorPersistConstraints(
+        private val resource: ParticipantEventResultPointsCalculatorResource,
+        private val mapper: ParticipantEventResultPointsCalculatorMapper
+) : Constraint<ParticipantEventResultPointsCalculator>() {
+
+    override fun assess(candidate: ParticipantEventResultPointsCalculator) {
+        constrain(
+                resource.stream { it.id != candidate.id }
+                        .map(mapper::fromSnoozle)
+                        .noneMatch { it.name == candidate.name }
+        ) { "Name is not unique" }
+    }
+    // TODO: prohibit alterations to event points calculators used for finalized events
+    // https://github.com/caeos/coner-trailer/issues/17
+}

--- a/modules/io/src/main/kotlin/org/coner/trailer/io/constraint/ParticipantEventResultPointsCalculatorPersistConstraints.kt
+++ b/modules/io/src/main/kotlin/org/coner/trailer/io/constraint/ParticipantEventResultPointsCalculatorPersistConstraints.kt
@@ -3,6 +3,7 @@ package org.coner.trailer.io.constraint
 import org.coner.trailer.datasource.snoozle.ParticipantEventResultPointsCalculatorResource
 import org.coner.trailer.io.mapper.ParticipantEventResultPointsCalculatorMapper
 import org.coner.trailer.seasonpoints.ParticipantEventResultPointsCalculator
+import java.util.*
 
 class ParticipantEventResultPointsCalculatorPersistConstraints(
         private val resource: ParticipantEventResultPointsCalculatorResource,
@@ -10,12 +11,11 @@ class ParticipantEventResultPointsCalculatorPersistConstraints(
 ) : Constraint<ParticipantEventResultPointsCalculator>() {
 
     override fun assess(candidate: ParticipantEventResultPointsCalculator) {
-        constrain(
-                resource.stream { it.id != candidate.id }
-                        .map(mapper::fromSnoozle)
-                        .noneMatch { it.name == candidate.name }
-        ) { "Name is not unique" }
+        constrain(hasUniqueName(candidate.id, candidate.name)) { "Name is not unique" }
+        // TODO: prohibit alterations to event points calculators used for finalized events
+        // https://github.com/caeos/coner-trailer/issues/17
     }
-    // TODO: prohibit alterations to event points calculators used for finalized events
-    // https://github.com/caeos/coner-trailer/issues/17
+
+    fun hasUniqueName(id: UUID, name: String) = resource.stream { it.id != id }
+            .noneMatch { it.name == name }
 }

--- a/modules/io/src/main/kotlin/org/coner/trailer/io/constraint/RankingSortPersistConstraints.kt
+++ b/modules/io/src/main/kotlin/org/coner/trailer/io/constraint/RankingSortPersistConstraints.kt
@@ -3,6 +3,7 @@ package org.coner.trailer.io.constraint
 import org.coner.trailer.datasource.snoozle.RankingSortResource
 import org.coner.trailer.io.mapper.RankingSortMapper
 import org.coner.trailer.seasonpoints.RankingSort
+import java.util.*
 
 class RankingSortPersistConstraints(
         private val resource: RankingSortResource,
@@ -10,10 +11,10 @@ class RankingSortPersistConstraints(
 ) : Constraint<RankingSort>() {
 
     override fun assess(candidate: RankingSort) {
-        constrain(
-                resource.stream { it.id != candidate.id }
-                        .map(mapper::fromSnoozle)
-                        .noneMatch { it.name == candidate.name }
-        ) { "Name is not unique" }
+        constrain(hasUniqueName(candidate.id, candidate.name)) { "Name is not unique" }
     }
+
+    fun hasUniqueName(id: UUID, name: String) = resource.stream { it.id != id }
+            .map(mapper::fromSnoozle)
+            .noneMatch { it.name == name }
 }

--- a/modules/io/src/main/kotlin/org/coner/trailer/io/constraint/RankingSortPersistConstraints.kt
+++ b/modules/io/src/main/kotlin/org/coner/trailer/io/constraint/RankingSortPersistConstraints.kt
@@ -1,0 +1,19 @@
+package org.coner.trailer.io.constraint
+
+import org.coner.trailer.datasource.snoozle.RankingSortResource
+import org.coner.trailer.io.mapper.RankingSortMapper
+import org.coner.trailer.seasonpoints.RankingSort
+
+class RankingSortPersistConstraints(
+        private val resource: RankingSortResource,
+        private val mapper: RankingSortMapper
+) : Constraint<RankingSort>() {
+
+    override fun assess(candidate: RankingSort) {
+        constrain(
+                resource.stream { it.id != candidate.id }
+                        .map(mapper::fromSnoozle)
+                        .noneMatch { it.name == candidate.name }
+        ) { "Name is not unique" }
+    }
+}

--- a/modules/io/src/main/kotlin/org/coner/trailer/io/mapper/RankingSortMapper.kt
+++ b/modules/io/src/main/kotlin/org/coner/trailer/io/mapper/RankingSortMapper.kt
@@ -9,12 +9,18 @@ class RankingSortMapper {
         return RankingSort(
                 id = snoozle.id,
                 name = snoozle.name,
-                steps = snoozle.steps.map { when (it.type) {
-                    RankingSortEntity.Step.Type.ScoreDescending -> RankingSort.Step.ScoreDescending
-                    RankingSortEntity.Step.Type.PositionFinishCountDescending -> RankingSort.Step.PositionFinishCountDescending(
-                            position = requireNotNull(it.paramInt1) { "${it.type} requires paramInt1 for position" }
-                    )
-                    RankingSortEntity.Step.Type.AverageMarginOfVictoryDescending -> RankingSort.Step.AverageMarginOfVictoryDescending
+                steps = snoozle.steps.map { step -> when (step.type) {
+                    RankingSortEntity.Step.Type.ScoreDescending -> {
+                        RankingSort.Step.ScoreDescending()
+                    }
+                    RankingSortEntity.Step.Type.PositionFinishCountDescending -> {
+                        RankingSort.Step.PositionFinishCountDescending(
+                                position = requireNotNull(step.paramInt1) { "${step.type} requires paramInt1 for position" }
+                        )
+                    }
+                    RankingSortEntity.Step.Type.AverageMarginOfVictoryDescending -> {
+                        RankingSort.Step.AverageMarginOfVictoryDescending()
+                    }
                 } }
         )
     }
@@ -24,7 +30,7 @@ class RankingSortMapper {
                 id = core.id,
                 name = core.name,
                 steps = core.steps.map { when (it) {
-                    RankingSort.Step.ScoreDescending -> {
+                    is RankingSort.Step.ScoreDescending -> {
                         RankingSortEntity.Step(
                                 type = RankingSortEntity.Step.Type.ScoreDescending
                         )
@@ -35,7 +41,7 @@ class RankingSortMapper {
                                 paramInt1 = it.position
                         )
                     }
-                    RankingSort.Step.AverageMarginOfVictoryDescending -> {
+                    is RankingSort.Step.AverageMarginOfVictoryDescending -> {
                         RankingSortEntity.Step(
                                 type = RankingSortEntity.Step.Type.AverageMarginOfVictoryDescending
                         )

--- a/modules/io/src/main/kotlin/org/coner/trailer/io/mapper/RankingSortMapper.kt
+++ b/modules/io/src/main/kotlin/org/coner/trailer/io/mapper/RankingSortMapper.kt
@@ -8,46 +8,39 @@ class RankingSortMapper {
     fun fromSnoozle(snoozle: RankingSortEntity): RankingSort {
         return RankingSort(
                 id = snoozle.id,
-                steps = mutableListOf<RankingSort.Step>().apply {
-                    snoozle.scoreDescendingSteps.forEach {
-                        set(it.index, RankingSort.Step.ScoreDescending)
-                    }
-                    snoozle.positionFinishCountDescendingSteps.forEach {
-                        set(it.index, RankingSort.Step.PositionFinishCountDescending(it.position))
-                    }
-                    snoozle.averageMarginOfVictoryDescendingSteps.forEach {
-                        set(it.index, RankingSort.Step.AverageMarginOfVictoryDescending)
-                    }
-                }
+                name = snoozle.name,
+                steps = snoozle.steps.map { when (it.type) {
+                    RankingSortEntity.Step.Type.ScoreDescending -> RankingSort.Step.ScoreDescending
+                    RankingSortEntity.Step.Type.PositionFinishCountDescending -> RankingSort.Step.PositionFinishCountDescending(
+                            position = requireNotNull(it.paramInt1) { "${it.type} requires paramInt1 for position" }
+                    )
+                    RankingSortEntity.Step.Type.AverageMarginOfVictoryDescending -> RankingSort.Step.AverageMarginOfVictoryDescending
+                } }
         )
     }
 
     fun toSnoozle(core: RankingSort): RankingSortEntity {
         return RankingSortEntity(
                 id = core.id,
-                scoreDescendingSteps = core.steps.mapIndexedNotNull { index, step ->
-                    when (step) {
-                        is RankingSort.Step.ScoreDescending -> RankingSortEntity.IndexOnlyStep(index)
-                        else -> null
+                name = core.name,
+                steps = core.steps.map { when (it) {
+                    RankingSort.Step.ScoreDescending -> {
+                        RankingSortEntity.Step(
+                                type = RankingSortEntity.Step.Type.ScoreDescending
+                        )
                     }
-                },
-                positionFinishCountDescendingSteps = core.steps.mapIndexedNotNull { index, step ->
-                    when (step) {
-                        is RankingSort.Step.PositionFinishCountDescending -> {
-                            RankingSortEntity.PositionFinishCountDescendingStep(
-                                    index = index,
-                                    position = step.position
-                            )
-                        }
-                        else -> null
+                    is RankingSort.Step.PositionFinishCountDescending -> {
+                        RankingSortEntity.Step(
+                                type = RankingSortEntity.Step.Type.PositionFinishCountDescending,
+                                paramInt1 = it.position
+                        )
                     }
-                },
-                averageMarginOfVictoryDescendingSteps = core.steps.mapIndexedNotNull { index, step ->
-                    when (step) {
-                        is RankingSort.Step.AverageMarginOfVictoryDescending -> RankingSortEntity.IndexOnlyStep(index)
-                        else -> null
+                    RankingSort.Step.AverageMarginOfVictoryDescending -> {
+                        RankingSortEntity.Step(
+                                type = RankingSortEntity.Step.Type.AverageMarginOfVictoryDescending
+                        )
                     }
-                }
+                } }
         )
     }
 }

--- a/modules/io/src/main/kotlin/org/coner/trailer/io/mapper/RankingSortMapper.kt
+++ b/modules/io/src/main/kotlin/org/coner/trailer/io/mapper/RankingSortMapper.kt
@@ -1,0 +1,49 @@
+package org.coner.trailer.io.mapper
+
+import org.coner.trailer.datasource.snoozle.entity.RankingSortEntity
+import org.coner.trailer.seasonpoints.RankingSort
+
+class RankingSortMapper {
+
+    fun fromSnoozle(snoozle: RankingSortEntity): RankingSort {
+        return RankingSort(
+                id = snoozle.id,
+                steps = snoozle.steps.map(::fromSnoozleStep)
+        )
+    }
+
+    fun toSnoozle(core: RankingSort): RankingSortEntity {
+        return RankingSortEntity(
+                id = core.id,
+                steps = core.steps.map(::toSnoozleStep)
+        )
+    }
+
+    private fun fromSnoozleStep(step: RankingSortEntity.Step): RankingSort.Step {
+        return when (step.type) {
+            "ScoreDescending" -> RankingSort.Step.ScoreDescending
+            "PositionFinishCountDescending" -> {
+                val position = requireNotNull(step.p1).toInt()
+                RankingSort.Step.PositionFinishCountDescending(position)
+            }
+            "AverageMarginOfVictoryDescending" -> RankingSort.Step.AverageMarginOfVictoryDescending
+            else -> throw IllegalArgumentException("Unrecognized step type: ${step.type}")
+        }
+    }
+
+    private fun toSnoozleStep(step: RankingSort.Step): RankingSortEntity.Step {
+        return when (step) {
+            RankingSort.Step.ScoreDescending -> RankingSortEntity.Step(
+                    type = "ScoreDescending"
+            )
+            is RankingSort.Step.PositionFinishCountDescending -> RankingSortEntity.Step(
+                    type = "PositionFinishCountDescending",
+                    p1 = step.position.toString()
+            )
+            RankingSort.Step.AverageMarginOfVictoryDescending -> RankingSortEntity.Step(
+                    type = "AverageMarginOfVictoryDescending"
+            )
+        }
+    }
+
+}

--- a/modules/io/src/main/kotlin/org/coner/trailer/io/mapper/RankingSortMapper.kt
+++ b/modules/io/src/main/kotlin/org/coner/trailer/io/mapper/RankingSortMapper.kt
@@ -8,42 +8,46 @@ class RankingSortMapper {
     fun fromSnoozle(snoozle: RankingSortEntity): RankingSort {
         return RankingSort(
                 id = snoozle.id,
-                steps = snoozle.steps.map(::fromSnoozleStep)
+                steps = mutableListOf<RankingSort.Step>().apply {
+                    snoozle.scoreDescendingSteps.forEach {
+                        set(it.index, RankingSort.Step.ScoreDescending)
+                    }
+                    snoozle.positionFinishCountDescendingSteps.forEach {
+                        set(it.index, RankingSort.Step.PositionFinishCountDescending(it.position))
+                    }
+                    snoozle.averageMarginOfVictoryDescendingSteps.forEach {
+                        set(it.index, RankingSort.Step.AverageMarginOfVictoryDescending)
+                    }
+                }
         )
     }
 
     fun toSnoozle(core: RankingSort): RankingSortEntity {
         return RankingSortEntity(
                 id = core.id,
-                steps = core.steps.map(::toSnoozleStep)
+                scoreDescendingSteps = core.steps.mapIndexedNotNull { index, step ->
+                    when (step) {
+                        is RankingSort.Step.ScoreDescending -> RankingSortEntity.IndexOnlyStep(index)
+                        else -> null
+                    }
+                },
+                positionFinishCountDescendingSteps = core.steps.mapIndexedNotNull { index, step ->
+                    when (step) {
+                        is RankingSort.Step.PositionFinishCountDescending -> {
+                            RankingSortEntity.PositionFinishCountDescendingStep(
+                                    index = index,
+                                    position = step.position
+                            )
+                        }
+                        else -> null
+                    }
+                },
+                averageMarginOfVictoryDescendingSteps = core.steps.mapIndexedNotNull { index, step ->
+                    when (step) {
+                        is RankingSort.Step.AverageMarginOfVictoryDescending -> RankingSortEntity.IndexOnlyStep(index)
+                        else -> null
+                    }
+                }
         )
     }
-
-    private fun fromSnoozleStep(step: RankingSortEntity.Step): RankingSort.Step {
-        return when (step.type) {
-            "ScoreDescending" -> RankingSort.Step.ScoreDescending
-            "PositionFinishCountDescending" -> {
-                val position = requireNotNull(step.p1).toInt()
-                RankingSort.Step.PositionFinishCountDescending(position)
-            }
-            "AverageMarginOfVictoryDescending" -> RankingSort.Step.AverageMarginOfVictoryDescending
-            else -> throw IllegalArgumentException("Unrecognized step type: ${step.type}")
-        }
-    }
-
-    private fun toSnoozleStep(step: RankingSort.Step): RankingSortEntity.Step {
-        return when (step) {
-            RankingSort.Step.ScoreDescending -> RankingSortEntity.Step(
-                    type = "ScoreDescending"
-            )
-            is RankingSort.Step.PositionFinishCountDescending -> RankingSortEntity.Step(
-                    type = "PositionFinishCountDescending",
-                    p1 = step.position.toString()
-            )
-            RankingSort.Step.AverageMarginOfVictoryDescending -> RankingSortEntity.Step(
-                    type = "AverageMarginOfVictoryDescending"
-            )
-        }
-    }
-
 }

--- a/modules/io/src/main/kotlin/org/coner/trailer/io/service/ParticipantEventResultPointsCalculatorService.kt
+++ b/modules/io/src/main/kotlin/org/coner/trailer/io/service/ParticipantEventResultPointsCalculatorService.kt
@@ -10,9 +10,10 @@ import kotlin.streams.toList
 class ParticipantEventResultPointsCalculatorService(
         private val resource: ParticipantEventResultPointsCalculatorResource,
         private val mapper: ParticipantEventResultPointsCalculatorMapper
-) {
+) : Service {
 
     fun create(calculator: ParticipantEventResultPointsCalculator) {
+        constrain(calculator.hasNewName()) { "Name: ${calculator.name} is not unique" }
         resource.create(mapper.toSnoozle(calculator))
     }
 
@@ -39,6 +40,7 @@ class ParticipantEventResultPointsCalculatorService(
     fun update(calculator: ParticipantEventResultPointsCalculator) {
         // TODO: prohibit update of event points calculators used for finalized events
         // https://github.com/caeos/coner-trailer/issues/17
+        constrain(calculator.hasNewName())
         resource.update(mapper.toSnoozle(calculator))
     }
 
@@ -46,7 +48,8 @@ class ParticipantEventResultPointsCalculatorService(
         resource.delete(mapper.toSnoozle(calculator))
     }
 
-    fun hasNewName(name: String): Boolean {
-        return resource.stream().noneMatch { it.name == name }
+    private fun ParticipantEventResultPointsCalculator.hasNewName(): Boolean {
+        return resource.stream()
+                .noneMatch { candidate -> candidate.name == name && candidate.id != id }
     }
 }

--- a/modules/io/src/main/kotlin/org/coner/trailer/io/service/ParticipantEventResultPointsCalculatorService.kt
+++ b/modules/io/src/main/kotlin/org/coner/trailer/io/service/ParticipantEventResultPointsCalculatorService.kt
@@ -2,6 +2,7 @@ package org.coner.trailer.io.service
 
 import org.coner.trailer.datasource.snoozle.ParticipantEventResultPointsCalculatorResource
 import org.coner.trailer.datasource.snoozle.entity.ParticipantEventResultPointsCalculatorEntity
+import org.coner.trailer.io.constraint.ParticipantEventResultPointsCalculatorPersistConstraints
 import org.coner.trailer.io.mapper.ParticipantEventResultPointsCalculatorMapper
 import org.coner.trailer.seasonpoints.ParticipantEventResultPointsCalculator
 import java.util.*
@@ -9,11 +10,12 @@ import kotlin.streams.toList
 
 class ParticipantEventResultPointsCalculatorService(
         private val resource: ParticipantEventResultPointsCalculatorResource,
-        private val mapper: ParticipantEventResultPointsCalculatorMapper
+        private val mapper: ParticipantEventResultPointsCalculatorMapper,
+        private val persistConstraints: ParticipantEventResultPointsCalculatorPersistConstraints,
 ) : Service {
 
     fun create(calculator: ParticipantEventResultPointsCalculator) {
-        constrain(calculator.hasNewName()) { "Name: ${calculator.name} is not unique" }
+        persistConstraints.assess(calculator)
         resource.create(mapper.toSnoozle(calculator))
     }
 
@@ -38,18 +40,14 @@ class ParticipantEventResultPointsCalculatorService(
     }
 
     fun update(calculator: ParticipantEventResultPointsCalculator) {
-        // TODO: prohibit update of event points calculators used for finalized events
-        // https://github.com/caeos/coner-trailer/issues/17
-        constrain(calculator.hasNewName())
+        persistConstraints.assess(calculator)
         resource.update(mapper.toSnoozle(calculator))
     }
 
     fun delete(calculator: ParticipantEventResultPointsCalculator) {
+        // TODO: prohibit deletions of event points calculators used for finalized events
+        // https://github.com/caeos/coner-trailer/issues/17
         resource.delete(mapper.toSnoozle(calculator))
     }
 
-    private fun ParticipantEventResultPointsCalculator.hasNewName(): Boolean {
-        return resource.stream()
-                .noneMatch { candidate -> candidate.name == name && candidate.id != id }
-    }
 }

--- a/modules/io/src/main/kotlin/org/coner/trailer/io/service/RankingSortService.kt
+++ b/modules/io/src/main/kotlin/org/coner/trailer/io/service/RankingSortService.kt
@@ -1,15 +1,18 @@
 package org.coner.trailer.io.service
 
 import org.coner.trailer.datasource.snoozle.RankingSortResource
+import org.coner.trailer.io.constraint.RankingSortPersistConstraints
 import org.coner.trailer.io.mapper.RankingSortMapper
 import org.coner.trailer.seasonpoints.RankingSort
 
 class RankingSortService(
         private val resource: RankingSortResource,
-        private val mapper: RankingSortMapper
+        private val mapper: RankingSortMapper,
+        private val persistConstraints: RankingSortPersistConstraints
 ) {
 
     fun create(rankingSort: RankingSort) {
+        persistConstraints.assess(rankingSort)
         resource.create(mapper.toSnoozle(rankingSort))
     }
 }

--- a/modules/io/src/main/kotlin/org/coner/trailer/io/service/RankingSortService.kt
+++ b/modules/io/src/main/kotlin/org/coner/trailer/io/service/RankingSortService.kt
@@ -1,9 +1,11 @@
 package org.coner.trailer.io.service
 
 import org.coner.trailer.datasource.snoozle.RankingSortResource
+import org.coner.trailer.datasource.snoozle.entity.RankingSortEntity
 import org.coner.trailer.io.constraint.RankingSortPersistConstraints
 import org.coner.trailer.io.mapper.RankingSortMapper
 import org.coner.trailer.seasonpoints.RankingSort
+import java.util.*
 
 class RankingSortService(
         private val resource: RankingSortResource,
@@ -14,5 +16,14 @@ class RankingSortService(
     fun create(rankingSort: RankingSort) {
         persistConstraints.assess(rankingSort)
         resource.create(mapper.toSnoozle(rankingSort))
+    }
+
+    fun findById(id: UUID): RankingSort {
+        val key = RankingSortEntity.Key(id = id)
+        return mapper.fromSnoozle(resource.read(key))
+    }
+
+    fun update(rankingSort: RankingSort) {
+        resource.update(mapper.toSnoozle(rankingSort))
     }
 }

--- a/modules/io/src/main/kotlin/org/coner/trailer/io/service/RankingSortService.kt
+++ b/modules/io/src/main/kotlin/org/coner/trailer/io/service/RankingSortService.kt
@@ -41,4 +41,8 @@ class RankingSortService(
                 .findFirst()
                 .orElse(null)
     }
+
+    fun delete(delete: RankingSort) {
+        resource.delete(mapper.toSnoozle(delete))
+    }
 }

--- a/modules/io/src/main/kotlin/org/coner/trailer/io/service/RankingSortService.kt
+++ b/modules/io/src/main/kotlin/org/coner/trailer/io/service/RankingSortService.kt
@@ -1,0 +1,10 @@
+package org.coner.trailer.io.service
+
+import org.coner.trailer.datasource.snoozle.RankingSortResource
+import org.coner.trailer.io.mapper.RankingSortMapper
+
+class RankingSortService(
+        private val resource: RankingSortResource,
+        private val mapper: RankingSortMapper
+) {
+}

--- a/modules/io/src/main/kotlin/org/coner/trailer/io/service/RankingSortService.kt
+++ b/modules/io/src/main/kotlin/org/coner/trailer/io/service/RankingSortService.kt
@@ -33,4 +33,12 @@ class RankingSortService(
                 .map(mapper::fromSnoozle)
                 .toList()
     }
+
+    fun findByName(name: String): RankingSort? {
+        return resource.stream()
+                .map(mapper::fromSnoozle)
+                .filter { it.name == name }
+                .findFirst()
+                .orElse(null)
+    }
 }

--- a/modules/io/src/main/kotlin/org/coner/trailer/io/service/RankingSortService.kt
+++ b/modules/io/src/main/kotlin/org/coner/trailer/io/service/RankingSortService.kt
@@ -6,6 +6,7 @@ import org.coner.trailer.io.constraint.RankingSortPersistConstraints
 import org.coner.trailer.io.mapper.RankingSortMapper
 import org.coner.trailer.seasonpoints.RankingSort
 import java.util.*
+import kotlin.streams.toList
 
 class RankingSortService(
         private val resource: RankingSortResource,
@@ -25,5 +26,11 @@ class RankingSortService(
 
     fun update(rankingSort: RankingSort) {
         resource.update(mapper.toSnoozle(rankingSort))
+    }
+
+    fun list(): List<RankingSort> {
+        return resource.stream()
+                .map(mapper::fromSnoozle)
+                .toList()
     }
 }

--- a/modules/io/src/main/kotlin/org/coner/trailer/io/service/RankingSortService.kt
+++ b/modules/io/src/main/kotlin/org/coner/trailer/io/service/RankingSortService.kt
@@ -2,9 +2,14 @@ package org.coner.trailer.io.service
 
 import org.coner.trailer.datasource.snoozle.RankingSortResource
 import org.coner.trailer.io.mapper.RankingSortMapper
+import org.coner.trailer.seasonpoints.RankingSort
 
 class RankingSortService(
         private val resource: RankingSortResource,
         private val mapper: RankingSortMapper
 ) {
+
+    fun create(rankingSort: RankingSort) {
+        resource.create(mapper.toSnoozle(rankingSort))
+    }
 }

--- a/modules/io/src/main/kotlin/org/coner/trailer/io/service/Service.kt
+++ b/modules/io/src/main/kotlin/org/coner/trailer/io/service/Service.kt
@@ -1,0 +1,8 @@
+package org.coner.trailer.io.service
+
+interface Service {
+
+    fun constrain(constraintSatisfied: Boolean, message: (() -> String)? = null) {
+        if (!constraintSatisfied) throw ServiceConstraintException(message?.invoke())
+    }
+}

--- a/modules/io/src/main/kotlin/org/coner/trailer/io/service/Service.kt
+++ b/modules/io/src/main/kotlin/org/coner/trailer/io/service/Service.kt
@@ -2,7 +2,5 @@ package org.coner.trailer.io.service
 
 interface Service {
 
-    fun constrain(constraintSatisfied: Boolean, message: (() -> String)? = null) {
-        if (!constraintSatisfied) throw ServiceConstraintException(message?.invoke())
-    }
+
 }

--- a/modules/io/src/main/kotlin/org/coner/trailer/io/service/ServiceConstraintException.kt
+++ b/modules/io/src/main/kotlin/org/coner/trailer/io/service/ServiceConstraintException.kt
@@ -1,3 +1,0 @@
-package org.coner.trailer.io.service
-
-class ServiceConstraintException(message: String?) : Throwable(message)

--- a/modules/io/src/main/kotlin/org/coner/trailer/io/service/ServiceConstraintException.kt
+++ b/modules/io/src/main/kotlin/org/coner/trailer/io/service/ServiceConstraintException.kt
@@ -1,0 +1,3 @@
+package org.coner.trailer.io.service
+
+class ServiceConstraintException(message: String?) : Throwable(message)

--- a/modules/io/src/test/kotlin/org/coner/trailer/io/constraint/RankingSortPersistConstraintsTest.kt
+++ b/modules/io/src/test/kotlin/org/coner/trailer/io/constraint/RankingSortPersistConstraintsTest.kt
@@ -1,0 +1,83 @@
+package org.coner.trailer.io.constraint
+
+import assertk.assertAll
+import assertk.assertThat
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import org.coner.trailer.datasource.snoozle.RankingSortResource
+import org.coner.trailer.datasource.snoozle.entity.RankingSortEntity
+import org.coner.trailer.io.mapper.RankingSortMapper
+import org.coner.trailer.seasonpoints.RankingSort
+import org.coner.trailer.seasonpoints.TestRankingSorts
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.extension.ExtendWith
+import java.util.stream.Stream
+
+@ExtendWith(MockKExtension::class)
+class RankingSortPersistConstraintsTest {
+
+    lateinit var constraints: RankingSortPersistConstraints
+
+    @MockK
+    lateinit var resource: RankingSortResource
+    lateinit var mapper: RankingSortMapper
+
+    @BeforeEach
+    fun before() {
+        mapper = RankingSortMapper()
+        constraints = RankingSortPersistConstraints(
+                resource = resource,
+                mapper = mapper
+        )
+    }
+
+    @Test
+    fun `It should assess valid candidate`() {
+        val rankingSorts = Stream.of(
+                mapper.toSnoozle(TestRankingSorts.lscc),
+                mapper.toSnoozle(TestRankingSorts.olscc)
+        )
+        every { resource.stream(any()) } returns rankingSorts
+        val candidate = RankingSort(
+                name = "candidate",
+                steps = listOf(RankingSort.Step.ScoreDescending())
+        )
+
+        assertDoesNotThrow {
+            constraints.assess(candidate)
+        }
+    }
+
+    @Test
+    fun `It should check name is unique`() {
+        val original = mapper.toSnoozle(TestRankingSorts.lscc)
+        every { resource.stream(any()) } answers  { Stream.of(original) }
+        val candidateWithDuplicateName = RankingSortEntity(
+                name = TestRankingSorts.lscc.name,
+                steps = emptyList()
+        )
+        val candidateWithUniqueName = RankingSortEntity(
+                name = "candidateWithUniqueName",
+                steps = emptyList()
+        )
+
+        val actualForDuplicate = constraints.hasUniqueName(
+                id = candidateWithDuplicateName.id,
+                name = candidateWithDuplicateName.name
+        )
+        val actualForUnique = constraints.hasUniqueName(
+                id = candidateWithUniqueName.id,
+                name = candidateWithUniqueName.name
+        )
+
+        assertAll {
+            assertThat(actualForDuplicate).isFalse()
+            assertThat(actualForUnique).isTrue()
+        }
+    }
+}

--- a/modules/io/src/test/kotlin/org/coner/trailer/io/service/ParticipantEventResultPointsCalculatorServiceTest.kt
+++ b/modules/io/src/test/kotlin/org/coner/trailer/io/service/ParticipantEventResultPointsCalculatorServiceTest.kt
@@ -12,6 +12,7 @@ import io.mockk.impl.annotations.MockK
 import org.coner.trailer.TestParticipantEventResultPointsCalculators
 import org.coner.trailer.datasource.snoozle.ParticipantEventResultPointsCalculatorResource
 import org.coner.trailer.datasource.snoozle.entity.ParticipantEventResultPointsCalculatorEntity
+import org.coner.trailer.io.constraint.ParticipantEventResultPointsCalculatorPersistConstraints
 import org.coner.trailer.io.mapper.ParticipantEventResultPointsCalculatorMapper
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -28,6 +29,8 @@ class ParticipantEventResultPointsCalculatorServiceTest {
     @MockK
     lateinit var mapper: ParticipantEventResultPointsCalculatorMapper
     @MockK
+    lateinit var persistConstraints: ParticipantEventResultPointsCalculatorPersistConstraints
+    @MockK
     lateinit var snoozleCalculator: ParticipantEventResultPointsCalculatorEntity
 
     @BeforeEach
@@ -35,7 +38,8 @@ class ParticipantEventResultPointsCalculatorServiceTest {
         MockKAnnotations.init(this)
         service = ParticipantEventResultPointsCalculatorService(
                 resource = resource,
-                mapper = mapper
+                mapper = mapper,
+                persistConstraints = persistConstraints
         )
     }
 

--- a/modules/io/src/test/kotlin/org/coner/trailer/io/service/ParticipantEventResultPointsCalculatorServiceTest.kt
+++ b/modules/io/src/test/kotlin/org/coner/trailer/io/service/ParticipantEventResultPointsCalculatorServiceTest.kt
@@ -46,6 +46,7 @@ class ParticipantEventResultPointsCalculatorServiceTest {
     @Test
     fun `It should create calculator`() {
         val calculator = TestParticipantEventResultPointsCalculators.lsccGroupingCalculator
+        every { persistConstraints.assess(calculator) } answers { Unit }
         every { mapper.toSnoozle(calculator) } returns snoozleCalculator
         every { resource.create(snoozleCalculator) } answers { Unit }
 
@@ -104,6 +105,7 @@ class ParticipantEventResultPointsCalculatorServiceTest {
     @Test
     fun `It should update calculators`() {
         val calculator = TestParticipantEventResultPointsCalculators.lsccGroupingCalculator
+        every { persistConstraints.assess(calculator) } answers { Unit }
         every { mapper.toSnoozle(calculator) } returns mockk()
         every { resource.update(any()) } returns Unit
 

--- a/modules/io/src/test/kotlin/org/coner/trailer/io/service/ParticipantEventResultPointsCalculatorServiceTest.kt
+++ b/modules/io/src/test/kotlin/org/coner/trailer/io/service/ParticipantEventResultPointsCalculatorServiceTest.kt
@@ -128,23 +128,4 @@ class ParticipantEventResultPointsCalculatorServiceTest {
         }
     }
 
-    @Test
-    fun `It should find out if name is new`() {
-        val lsccGrouping = TestParticipantEventResultPointsCalculators.lsccGroupingCalculator
-        val lsccOverall = TestParticipantEventResultPointsCalculators.lsccOverallCalculator
-        every { resource.stream() } answers { Stream.of(
-                mockk { every { name } returns lsccGrouping.name },
-                mockk { every { name } returns lsccOverall.name }
-        ) }
-        every { mapper.fromSnoozle(match { it.name == lsccGrouping.name }) } returns lsccGrouping
-        every { mapper.fromSnoozle(match { it.name == lsccOverall.name }) } returns lsccOverall
-
-        val actualNotNew = service.hasNewName(lsccGrouping.name)
-        val actualNew = service.hasNewName(UUID.randomUUID().toString())
-
-        assertAll {
-            assertThat(actualNotNew, "not new case").isFalse()
-            assertThat(actualNew, "new case").isTrue()
-        }
-    }
 }

--- a/modules/io/src/test/kotlin/org/coner/trailer/io/service/RankingSortServiceTest.kt
+++ b/modules/io/src/test/kotlin/org/coner/trailer/io/service/RankingSortServiceTest.kt
@@ -5,6 +5,7 @@ import assertk.assertions.isSameAs
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import io.mockk.verifySequence
 import org.coner.trailer.datasource.snoozle.RankingSortResource
@@ -15,7 +16,9 @@ import org.coner.trailer.seasonpoints.RankingSort
 import org.coner.trailer.seasonpoints.TestRankingSorts
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 
+@ExtendWith(MockKExtension::class)
 class RankingSortServiceTest {
 
     lateinit var service: RankingSortService
@@ -31,7 +34,6 @@ class RankingSortServiceTest {
 
     @BeforeEach
     fun before() {
-        MockKAnnotations.init(this)
         service = RankingSortService(
                 resource = resource,
                 mapper = mapper,
@@ -83,6 +85,22 @@ class RankingSortServiceTest {
         verifySequence {
             mapper.toSnoozle(rankingSort)
             resource.update(rankingSortEntity)
+        }
+    }
+
+    @Test
+    fun `It should delete ranking sort`(
+            @MockK rankingSort: RankingSort,
+            @MockK rankingSortSnoozle: RankingSortEntity
+    ) {
+        every { mapper.toSnoozle(rankingSort) } returns rankingSortSnoozle
+        every { resource.delete(rankingSortSnoozle) } answers { Unit }
+
+        service.delete(rankingSort)
+
+        verifySequence {
+            mapper.toSnoozle(rankingSort)
+            resource.delete(rankingSortSnoozle)
         }
     }
 }

--- a/modules/io/src/test/kotlin/org/coner/trailer/io/service/RankingSortServiceTest.kt
+++ b/modules/io/src/test/kotlin/org/coner/trailer/io/service/RankingSortServiceTest.kt
@@ -1,5 +1,7 @@
 package org.coner.trailer.io.service
 
+import assertk.assertThat
+import assertk.assertions.isSameAs
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -10,6 +12,7 @@ import org.coner.trailer.datasource.snoozle.entity.RankingSortEntity
 import org.coner.trailer.io.constraint.RankingSortPersistConstraints
 import org.coner.trailer.io.mapper.RankingSortMapper
 import org.coner.trailer.seasonpoints.RankingSort
+import org.coner.trailer.seasonpoints.TestRankingSorts
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -49,6 +52,37 @@ class RankingSortServiceTest {
             persistConstraints.assess(rankingSort)
             mapper.toSnoozle(rankingSort)
             resource.create(snoozle)
+        }
+    }
+
+    @Test
+    fun `It should find ranking sort by ID`() {
+        val rankingSort = TestRankingSorts.lscc
+        val rankingSortEntity: RankingSortEntity = mockk()
+        every { resource.read(match { it.id == rankingSort.id }) } returns rankingSortEntity
+        every { mapper.fromSnoozle(rankingSortEntity) } returns rankingSort
+
+        val actual = service.findById(rankingSort.id)
+
+        verifySequence {
+            resource.read(match { it.id == rankingSort.id })
+            mapper.fromSnoozle(rankingSortEntity)
+        }
+        assertThat(actual).isSameAs(rankingSort)
+    }
+
+    @Test
+    fun `It should update ranking sort`() {
+        val rankingSort = TestRankingSorts.lscc
+        val rankingSortEntity: RankingSortEntity = mockk()
+        every { mapper.toSnoozle(rankingSort) } returns rankingSortEntity
+        every { resource.update(rankingSortEntity) } answers { Unit }
+
+        service.update(rankingSort)
+
+        verifySequence {
+            mapper.toSnoozle(rankingSort)
+            resource.update(rankingSortEntity)
         }
     }
 }

--- a/modules/io/src/test/kotlin/org/coner/trailer/io/service/RankingSortServiceTest.kt
+++ b/modules/io/src/test/kotlin/org/coner/trailer/io/service/RankingSortServiceTest.kt
@@ -1,0 +1,54 @@
+package org.coner.trailer.io.service
+
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.verifySequence
+import org.coner.trailer.datasource.snoozle.RankingSortResource
+import org.coner.trailer.datasource.snoozle.entity.RankingSortEntity
+import org.coner.trailer.io.constraint.RankingSortPersistConstraints
+import org.coner.trailer.io.mapper.RankingSortMapper
+import org.coner.trailer.seasonpoints.RankingSort
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class RankingSortServiceTest {
+
+    lateinit var service: RankingSortService
+
+    @MockK
+    lateinit var resource: RankingSortResource
+    @MockK
+    lateinit var mapper: RankingSortMapper
+    @MockK
+    lateinit var persistConstraints: RankingSortPersistConstraints
+    @MockK
+    lateinit var rankingSort: RankingSort
+
+    @BeforeEach
+    fun before() {
+        MockKAnnotations.init(this)
+        service = RankingSortService(
+                resource = resource,
+                mapper = mapper,
+                persistConstraints = persistConstraints
+        )
+    }
+
+    @Test
+    fun `It should create ranking sort`() {
+        every { persistConstraints.assess(rankingSort) } answers { Unit }
+        val snoozle: RankingSortEntity = mockk()
+        every { mapper.toSnoozle(rankingSort) } returns snoozle
+        every { resource.create(snoozle) } answers { Unit }
+
+        service.create(rankingSort)
+
+        verifySequence {
+            persistConstraints.assess(rankingSort)
+            mapper.toSnoozle(rankingSort)
+            resource.create(snoozle)
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kotlin.version>1.3.72</kotlin.version>
+        <kotlin.version>1.4.0</kotlin.version>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
         <kotlinx.html.version>0.7.1</kotlinx.html.version>
         <kodein.version>7.0.0</kodein.version>


### PR DESCRIPTION
Adds CLI CRUD functionality for ranking sorts. 

This ended up turning out a little different than originally envisioned due to a limitation in the CLI framework (or maybe overly ambitious expectations on my part). I had expected to use a mutually exclusive option group to build the list of option choices for sort steps. Couldn't figure out how to accomplish that, since the group and mutually exclusive options don't support `.multiple()` like the single argument/option models do. It strikes me as more important to keep up velocity on useful functionality on this project than it is to have a slightly simpler CLI as originally envisioned.

Add a ranking sort
```no-highlight
ranking-sort add --id "44e525c6-aeba-4edc-b5c0-a9abf1172c57" --name "name" --score-descending
```
Append position-finish-count 1-3 steps for tie-breaking
```no-highlight
ranking-sort steps-append 44e525c6-aeba-4edc-b5c0-a9abf1172c57 --position-finish-count-descending --position 1
ranking-sort steps-append 44e525c6-aeba-4edc-b5c0-a9abf1172c57 --position-finish-count-descending --position 2
ranking-sort steps-append 44e525c6-aeba-4edc-b5c0-a9abf1172c57 --position-finish-count-descending --position 3
```

List ranking sorts

```no-highlight
ranking-sort list
```

Get a ranking sort by name or ID
```no-highlight
ranking-sort get --name "THSCC v1"
ranking-sort get --id "44e525c6-aeba-4edc-b5c0-a9abf1172c57"
```

Delete a ranking sort
```no-highlight
ranking-sort delete "44e525c6-aeba-4edc-b5c0-a9abf1172c57"
```